### PR TITLE
ifc-file header fix

### DIFF
--- a/IfcPlusPlus/src/ifcpp/writer/IfcPPWriterSTEP.cpp
+++ b/IfcPlusPlus/src/ifcpp/writer/IfcPPWriterSTEP.cpp
@@ -41,7 +41,10 @@ void IfcPPWriterSTEP::writeModelToStream( std::stringstream& stream, shared_ptr<
 	
 	const std::wstring& file_header_wstr = model->getFileHeader();
 	std::string file_header_str = encodeStepString( file_header_wstr );
+	stream << "ISO-10303-21;\n";
+	stream << "HEADER;";
 	stream << file_header_str.c_str();
+	stream << "ENDSEC;\n";
 	stream << "DATA;\n";
 	stream << std::setprecision( 15 );
 	stream << std::setiosflags( std::ios::showpoint );


### PR DESCRIPTION
The ifc-file was missing the initial "ISO-10303-21;", the "HEADER;" infront of the header and "ENDSEC;" after the header.
I fixed that.
Now the following holds true: Load(Save(Load(file))) == Load(file).
I tested that with a very simple file, and with a very complex file, namely this one: http://openifcmodel.cs.auckland.ac.nz/_models/20160125WestRiverSide%20Hospital%20-%20IFC4-Autodesk_Hospital_Sprinkle.ifc