### PR TITLE
Fix writing of 2D lists for a few entities.

### DIFF
--- a/IfcPlusPlus/src/ifcpp/IFC4/lib/IfcColourRgbList.cpp
+++ b/IfcPlusPlus/src/ifcpp/IFC4/lib/IfcColourRgbList.cpp
@@ -36,32 +36,7 @@ shared_ptr<IfcPPObject> IfcColourRgbList::getDeepCopy( IfcPPCopyOptions& options
 void IfcColourRgbList::getStepLine( std::stringstream& stream ) const
 {
 	stream << "#" << m_entity_id << "= IFCCOLOURRGBLIST" << "(";
-	stream << "("; 
-	for( size_t ii = 0; ii < m_ColourList.size(); ++ii )
-	{
-		const std::vector<shared_ptr<IfcNormalisedRatioMeasure> >&inner_vec = m_ColourList[ii];
-		if( ii > 0 )
-		{
-			stream << "), (";
-		}
-		for( size_t jj = 0; jj < inner_vec.size(); ++jj )
-		{
-			if( jj > 0 )
-			{
-				stream << ", ";
-			}
-			const shared_ptr<IfcNormalisedRatioMeasure>& type_object = inner_vec[jj];
-			if( type_object )
-			{
-				type_object->getStepParameter( stream, false );
-			}
-			else
-			{
-				stream << "$";
-			}
-		}
-	}
-	stream << ")"; 
+	writeNumericList2D(stream, m_ColourList);
 	stream << ");";
 }
 void IfcColourRgbList::getStepParameter( std::stringstream& stream, bool ) const { stream << "#" << m_entity_id; }

--- a/IfcPlusPlus/src/ifcpp/IFC4/lib/IfcIndexedPolygonalFaceWithVoids.cpp
+++ b/IfcPlusPlus/src/ifcpp/IFC4/lib/IfcIndexedPolygonalFaceWithVoids.cpp
@@ -66,32 +66,7 @@ void IfcIndexedPolygonalFaceWithVoids::getStepLine( std::stringstream& stream ) 
 	}
 	stream << ")";
 	stream << ",";
-	stream << "("; 
-	for( size_t ii = 0; ii < m_InnerCoordIndices.size(); ++ii )
-	{
-		const std::vector<shared_ptr<IfcPositiveInteger> >&inner_vec = m_InnerCoordIndices[ii];
-		if( ii > 0 )
-		{
-			stream << "), (";
-		}
-		for( size_t jj = 0; jj < inner_vec.size(); ++jj )
-		{
-			if( jj > 0 )
-			{
-				stream << ", ";
-			}
-			const shared_ptr<IfcPositiveInteger>& type_object = inner_vec[jj];
-			if( type_object )
-			{
-				type_object->getStepParameter( stream, false );
-			}
-			else
-			{
-				stream << "$";
-			}
-		}
-	}
-	stream << ")"; 
+	writeNumericTypeList2D(stream, m_InnerCoordIndices);
 	stream << ");";
 }
 void IfcIndexedPolygonalFaceWithVoids::getStepParameter( std::stringstream& stream, bool ) const { stream << "#" << m_entity_id; }

--- a/IfcPlusPlus/src/ifcpp/IFC4/lib/IfcIndexedTriangleTextureMap.cpp
+++ b/IfcPlusPlus/src/ifcpp/IFC4/lib/IfcIndexedTriangleTextureMap.cpp
@@ -55,32 +55,7 @@ void IfcIndexedTriangleTextureMap::getStepLine( std::stringstream& stream ) cons
 	stream << ",";
 	if( m_TexCoords ) { stream << "#" << m_TexCoords->m_entity_id; } else { stream << "*"; }
 	stream << ",";
-	stream << "("; 
-	for( size_t ii = 0; ii < m_TexCoordIndex.size(); ++ii )
-	{
-		const std::vector<shared_ptr<IfcPositiveInteger> >&inner_vec = m_TexCoordIndex[ii];
-		if( ii > 0 )
-		{
-			stream << "), (";
-		}
-		for( size_t jj = 0; jj < inner_vec.size(); ++jj )
-		{
-			if( jj > 0 )
-			{
-				stream << ", ";
-			}
-			const shared_ptr<IfcPositiveInteger>& type_object = inner_vec[jj];
-			if( type_object )
-			{
-				type_object->getStepParameter( stream, false );
-			}
-			else
-			{
-				stream << "$";
-			}
-		}
-	}
-	stream << ")"; 
+	writeNumericTypeList2D(stream, m_TexCoordIndex);
 	stream << ");";
 }
 void IfcIndexedTriangleTextureMap::getStepParameter( std::stringstream& stream, bool ) const { stream << "#" << m_entity_id; }

--- a/IfcPlusPlus/src/ifcpp/IFC4/lib/IfcTriangulatedFaceSet.cpp
+++ b/IfcPlusPlus/src/ifcpp/IFC4/lib/IfcTriangulatedFaceSet.cpp
@@ -73,32 +73,7 @@ void IfcTriangulatedFaceSet::getStepLine( std::stringstream& stream ) const
 	stream << ",";
 	if( m_Closed ) { m_Closed->getStepParameter( stream ); } else { stream << "$"; }
 	stream << ",";
-	stream << "("; 
-	for( size_t ii = 0; ii < m_CoordIndex.size(); ++ii )
-	{
-		const std::vector<shared_ptr<IfcPositiveInteger> >&inner_vec = m_CoordIndex[ii];
-		if( ii > 0 )
-		{
-			stream << "), (";
-		}
-		for( size_t jj = 0; jj < inner_vec.size(); ++jj )
-		{
-			if( jj > 0 )
-			{
-				stream << ", ";
-			}
-			const shared_ptr<IfcPositiveInteger>& type_object = inner_vec[jj];
-			if( type_object )
-			{
-				type_object->getStepParameter( stream, false );
-			}
-			else
-			{
-				stream << "$";
-			}
-		}
-	}
-	stream << ")"; 
+	writeNumericTypeList2D(stream, m_CoordIndex);
 	stream << ",";
 	stream << "(";
 	for( size_t ii = 0; ii < m_PnIndex.size(); ++ii )


### PR DESCRIPTION
Affected were ColourRGBList, PolygonalFaceWithVoids, IndexedTriangleTextureMap, and TriangulatedFaceSet.

I noticed TriangulatedFaceSets were missing a pair of parentheses when writing IFC files. The writer utilities already provide a function to write such lists, so I replaced the code in every class using such a construct (which wasn't already using writeNumericList2D)