### PR TITLE
styles converter transparency fix and code modernisation

### DIFF
--- a/IfcPlusPlus/src/ifcpp/geometry/Carve/GeometryConverter.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/Carve/GeometryConverter.h
@@ -237,15 +237,14 @@ public:
 				continue;
 			}
 
-			shared_ptr<IfcComplexProperty> complex_property = dynamic_pointer_cast<IfcComplexProperty>(ifc_property);
+			auto const complex_property = dynamic_pointer_cast<IfcComplexProperty>(ifc_property);
 			if( complex_property )
 			{
 				if( !complex_property->m_UsageName ) continue;
 				if( complex_property->m_UsageName->m_value.compare( L"Color" ) == 0 )
 				{
-					vec4 vec_color;
-					m_representation_converter->getStylesConverter()->convertIfcComplexPropertyColor( complex_property, vec_color );
-					shared_ptr<AppearanceData> appearance_data( new AppearanceData( -1 ) );
+					auto const vec_color = m_representation_converter->getStylesConverter()->convertIfcComplexPropertyColor( complex_property );
+					auto appearance_data = std::make_shared<AppearanceData>( -1 );
 					if( !appearance_data )
 					{
 						throw OutOfMemoryException( __FUNC__ );

--- a/IfcPlusPlus/src/ifcpp/geometry/Carve/GeometryInputData.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/Carve/GeometryInputData.h
@@ -471,7 +471,7 @@ public:
 		std::copy( other->m_vec_representation_appearances.begin(), other->m_vec_representation_appearances.end(), std::back_inserter( m_vec_representation_appearances ) );
 	}
 
-	void addAppearance( shared_ptr<AppearanceData>& appearance )
+	void addAppearance( shared_ptr<AppearanceData> const& appearance )
 	{
 		if( !appearance )
 		{

--- a/IfcPlusPlus/src/ifcpp/geometry/Carve/RepresentationConverter.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/Carve/RepresentationConverter.h
@@ -387,8 +387,7 @@ public:
 							shared_ptr<IfcPresentationStyle>&  presentation_style = vec_presentation_styles[ii_style];
 							if( presentation_style )
 							{
-								shared_ptr<AppearanceData> appearance_data;
-								m_styles_converter->convertIfcPresentationStyle( presentation_style, appearance_data );
+								auto const appearance_data = m_styles_converter->convertIfcPresentationStyle( presentation_style );
 								if( appearance_data )
 								{
 									representation_data->addAppearance( appearance_data );

--- a/IfcPlusPlus/src/ifcpp/geometry/Carve/RepresentationConverter.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/Carve/RepresentationConverter.h
@@ -140,15 +140,17 @@ public:
 		m_face_converter->m_unit_converter = unit_converter;
 	}
 
-	void convertRepresentationStyle( const shared_ptr<IfcRepresentationItem>& representation_item, std::vector<shared_ptr<AppearanceData> >& vec_appearance_data )
+	std::vector<shared_ptr<AppearanceData> > convertRepresentationStyle( const shared_ptr<IfcRepresentationItem>& representation_item )
 	{
 		std::vector<weak_ptr<IfcStyledItem> >&	vec_StyledByItem_inverse = representation_item->m_StyledByItem_inverse;
+		std::vector<shared_ptr<AppearanceData> > vec_appearance_data;
 		for( size_t i = 0; i < vec_StyledByItem_inverse.size(); ++i )
 		{
 			weak_ptr<IfcStyledItem> styled_item_weak = vec_StyledByItem_inverse[i];
 			shared_ptr<IfcStyledItem> styled_item = shared_ptr<IfcStyledItem>( styled_item_weak );
 			m_styles_converter->convertIfcStyledItem( styled_item, vec_appearance_data );
 		}
+		return vec_appearance_data;
 	}
 
 	void convertIfcRepresentation( const shared_ptr<IfcRepresentation>& ifc_representation, shared_ptr<RepresentationData>& representation_data )
@@ -205,7 +207,7 @@ public:
 		{
 			shared_ptr<IfcRepresentationItem> representation_item = ifc_representation->m_Items[i_representation_items];
 
-			//ENTITY IfcRepresentationItem  ABSTRACT SUPERTYPE OF(ONEOF(IfcGeometricRepresentationItem, IfcMappedItem, IfcStyledItem, IfcTopologicalRepresentationItem));
+			//ENTITY IfcRepresentationItem	ABSTRACT SUPERTYPE OF(ONEOF(IfcGeometricRepresentationItem, IfcMappedItem, IfcStyledItem, IfcTopologicalRepresentationItem));
 			shared_ptr<IfcGeometricRepresentationItem> geom_item = dynamic_pointer_cast<IfcGeometricRepresentationItem>( representation_item );
 			if( geom_item )
 			{
@@ -300,8 +302,7 @@ public:
 
 				if( m_geom_settings->handleStyledItems() )
 				{
-					std::vector<shared_ptr<AppearanceData> > vec_appearance_data;
-					convertRepresentationStyle( representation_item, vec_appearance_data );
+					auto const vec_appearance_data = convertRepresentationStyle( representation_item );
 
 					if( vec_appearance_data.size() > 0 )
 					{
@@ -313,7 +314,7 @@ public:
 
 							for( size_t jj_appearance = 0; jj_appearance < vec_appearance_data.size(); ++jj_appearance )
 							{
-								shared_ptr<AppearanceData>& data = vec_appearance_data[jj_appearance];
+								auto const& data = vec_appearance_data[jj_appearance];
 								if( data )
 								{
 									mapped_item_data->m_vec_item_appearances.push_back( data );
@@ -409,8 +410,7 @@ public:
 		//IfcSolidModel, IfcSurface, IfcTessellatedItem, IfcTextLiteral, IfcVector))
 		if( m_geom_settings->handleStyledItems() )
 		{
-			std::vector<shared_ptr<AppearanceData> > vec_appearance_data;
-			convertRepresentationStyle( geom_item, vec_appearance_data );
+			auto const vec_appearance_data = convertRepresentationStyle( geom_item );
 			std::copy( vec_appearance_data.begin(), vec_appearance_data.end(), std::back_inserter( item_data->m_vec_item_appearances ) );
 		}
 		
@@ -609,9 +609,9 @@ public:
 		shared_ptr<IfcTextLiteral> text_literal = dynamic_pointer_cast<IfcTextLiteral>( geom_item );
 		if( text_literal )
 		{
-			// Literal		: 	IfcPresentableText;
-			// Placement	: 	IfcAxis2Placement;
-			// Path			: 	IfcTextPath;
+			// Literal		:	IfcPresentableText;
+			// Placement	:	IfcAxis2Placement;
+			// Path			:	IfcTextPath;
 			if( m_geom_settings->isShowTextLiterals() )
 			{
 				shared_ptr<IfcPresentableText>& ifc_literal = text_literal->m_Literal;
@@ -715,7 +715,7 @@ public:
 
 	void convertTopologicalRepresentationItem( const shared_ptr<IfcTopologicalRepresentationItem>& topological_item, shared_ptr<ItemShapeData> topo_item_data )
 	{
-		//IfcTopologicalRepresentationItem 		ABSTRACT SUPERTYPE OF(ONEOF(IfcConnectedFaceSet, IfcEdge, IfcFace, IfcFaceBound, IfcLoop, IfcPath, IfcVertex))
+		//IfcTopologicalRepresentationItem		ABSTRACT SUPERTYPE OF(ONEOF(IfcConnectedFaceSet, IfcEdge, IfcFace, IfcFaceBound, IfcLoop, IfcPath, IfcVertex))
 		const shared_ptr<IfcConnectedFaceSet> topo_connected_face_set = dynamic_pointer_cast<IfcConnectedFaceSet>( topological_item );
 		if( topo_connected_face_set )
 		{
@@ -761,9 +761,9 @@ public:
 			//shared_ptr<IfcFaceSurface> topo_face_surface = dynamic_pointer_cast<IfcFaceSurface>( topo_face );
 			//if( topo_face_surface )
 			//{
-			//	//  std::vector<shared_ptr<IfcFaceBound> >					m_Bounds;
-			//	//  shared_ptr<IfcSurface>									m_FaceSurface;
-			//	//  bool													m_SameSense;
+			//	//	std::vector<shared_ptr<IfcFaceBound> >					m_Bounds;
+			//	//	shared_ptr<IfcSurface>									m_FaceSurface;
+			//	//	bool													m_SameSense;
 
 			//	const shared_ptr<IfcSurface>& face_surface = topo_face_surface->m_FaceSurface;
 			//	if( face_surface )

--- a/IfcPlusPlus/src/ifcpp/geometry/StylesConverter.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/StylesConverter.h
@@ -354,13 +354,13 @@ public:
 		}
 	}
 
-	void convertIfcComplexPropertyColor( shared_ptr<IfcComplexProperty> complex_property, vec4& vec_color )
+	vec4 convertIfcComplexPropertyColor( shared_ptr<IfcComplexProperty> const& complex_property )
 	{
 		std::vector<shared_ptr<IfcProperty> >& vec_HasProperties = complex_property->m_HasProperties;
-		if( !complex_property->m_UsageName ) return;
-		if( vec_HasProperties.size() < 3 ) return;
+		if( !complex_property->m_UsageName ) return {};
+		if( vec_HasProperties.size() < 3 ) return {};
 		std::wstring usage_name = complex_property->m_UsageName->m_value;
-		if( !boost::iequals( usage_name.c_str(), L"Color" ) ) return;
+		if( !boost::iequals( usage_name.c_str(), L"Color" ) ) return {};
 
 		if( complex_property->m_HasProperties.size() > 2 )
 		{
@@ -391,11 +391,7 @@ public:
 							g = 0.12;
 							b = 0.15;
 						}
-						vec_color.m_r = r;
-						vec_color.m_g = g;
-						vec_color.m_b = b;
-						vec_color.m_a = 1.0;
-
+						return { r, g, b, 1.0 };
 #ifdef ENABLE_OPENMP
 						//ScopedLock lock( m_writelock_styles_converter );
 #endif
@@ -405,12 +401,11 @@ public:
 						//appearance_data->shininess = 35.f;
 
 						//m_map_ifc_styles[complex_property_id] = appearance_data;
-
-						return;
 					}
 				}
 			}
 		}
+		return {};
 	}
 
 	void convertIfcPresentationStyle( shared_ptr<IfcPresentationStyle> presentation_style, shared_ptr<AppearanceData>& appearance_data )

--- a/IfcPlusPlus/src/ifcpp/geometry/StylesConverter.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/StylesConverter.h
@@ -342,8 +342,7 @@ public:
 			shared_ptr<IfcPresentationStyle> presentation_style = dynamic_pointer_cast<IfcPresentationStyle>( style_assign_select );
 			if( presentation_style )
 			{
-				shared_ptr<AppearanceData> appearance_data;
-				convertIfcPresentationStyle( presentation_style, appearance_data );
+				auto const appearance_data = convertIfcPresentationStyle( presentation_style );
 				if( appearance_data )
 				{
 					vec_appearance_data.push_back( appearance_data );
@@ -408,9 +407,10 @@ public:
 		return {};
 	}
 
-	void convertIfcPresentationStyle( shared_ptr<IfcPresentationStyle> presentation_style, shared_ptr<AppearanceData>& appearance_data )
+	shared_ptr<AppearanceData> convertIfcPresentationStyle( shared_ptr<IfcPresentationStyle> presentation_style )
 	{
 		int style_id = presentation_style->m_entity_id;
+		shared_ptr<AppearanceData> appearance_data;
 		auto it_find_existing_style = m_map_ifc_styles.find( style_id );
 		if( it_find_existing_style != m_map_ifc_styles.end() )
 		{
@@ -418,7 +418,7 @@ public:
 			appearance_data = it_find_existing_style->second;
 			if( appearance_data->m_complete )
 			{
-				return;
+				return appearance_data;
 			}
 		}
 		else
@@ -438,7 +438,7 @@ public:
 		if( curve_style )
 		{
 			convertIfcCurveStyle( curve_style, appearance_data );
-			return;
+			return appearance_data;
 		}
 
 		shared_ptr<IfcFillAreaStyle> fill_area_style = dynamic_pointer_cast<IfcFillAreaStyle>( presentation_style );
@@ -447,14 +447,14 @@ public:
 #ifdef _DEBUG
 			std::cout << "IfcFillAreaStyle not implemented" << std::endl;
 #endif
-			return;
+			return appearance_data;
 		}
 
 		shared_ptr<IfcSurfaceStyle> surface_style = dynamic_pointer_cast<IfcSurfaceStyle>( presentation_style );
 		if( surface_style )
 		{
 			convertIfcSurfaceStyle( surface_style, appearance_data );
-			return;
+			return appearance_data;
 		}
 
 		shared_ptr<IfcTextStyle> text_style = dynamic_pointer_cast<IfcTextStyle>( presentation_style );
@@ -462,10 +462,10 @@ public:
 		{
 			appearance_data->m_text_style = text_style;
 			appearance_data->m_complete = true;
-			return;
+			return appearance_data;
 		}
 
-		return;
+		return appearance_data;
 	}
 
 private:

--- a/IfcPlusPlus/src/ifcpp/geometry/StylesConverter.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/StylesConverter.h
@@ -78,96 +78,6 @@ public:
 	{
 		m_map_ifc_styles.clear();
 	}
-
-	void convertIfcSpecularHighlightSelect( shared_ptr<IfcSpecularHighlightSelect> highlight_select, shared_ptr<AppearanceData>& appearance_data )
-	{
-		if( dynamic_pointer_cast<IfcSpecularExponent>( highlight_select ) )
-		{
-			shared_ptr<IfcSpecularExponent> spec = dynamic_pointer_cast<IfcSpecularExponent>( highlight_select );
-			appearance_data->m_specular_exponent = spec->m_value;
-		}
-		else if( dynamic_pointer_cast<IfcSpecularRoughness>( highlight_select ) )
-		{
-			shared_ptr<IfcSpecularRoughness> specular_roughness = dynamic_pointer_cast<IfcSpecularRoughness>( highlight_select );
-			appearance_data->m_specular_roughness = specular_roughness->m_value;
-		}
-	}
-
-	void convertIfcColourRgb( shared_ptr<IfcColourRgb> color_rgb, vec4& color )
-	{
-		if( color_rgb->m_Red )
-		{
-			color.m_r = (float)color_rgb->m_Red->m_value;
-		}
-		if( color_rgb->m_Green )
-		{
-			color.m_g = (float)color_rgb->m_Green->m_value;
-		}
-		if( color_rgb->m_Blue )
-		{
-			color.m_b = (float)color_rgb->m_Blue->m_value;
-		}
-	}
-
-	void convertIfcColourOrFactor( shared_ptr<IfcColourOrFactor> color_or_factor, vec4& src_color, vec4& target_color )
-	{
-		// TYPE IfcColourOrFactor = SELECT ( IfcNormalisedRatioMeasure, IfcColourRgb);
-		shared_ptr<IfcColourRgb> color_rgb = dynamic_pointer_cast<IfcColourRgb>( color_or_factor );
-		if( color_rgb )
-		{
-			convertIfcColourRgb( color_rgb, target_color );
-			return;
-		}
-
-		shared_ptr<IfcNormalisedRatioMeasure> ratio_measure = dynamic_pointer_cast<IfcNormalisedRatioMeasure>( color_or_factor );
-		if( ratio_measure )
-		{
-			float factor = ratio_measure->m_value;
-			target_color.setColor( src_color.r()*factor, src_color.g()*factor, src_color.b()*factor, src_color.a() );
-			return;
-		}
-	}
-
-	void convertIfcColour( shared_ptr<IfcColour> ifc_color_select, vec4& color )
-	{
-		// IfcColour = SELECT ( IfcColourSpecification, IfcPreDefinedColour );
-		shared_ptr<IfcColourSpecification> color_spec = dynamic_pointer_cast<IfcColourSpecification>( ifc_color_select );
-		if( color_spec )
-		{
-			// ENTITY IfcColourSpecification ABSTRACT SUPERTYPE OF(IfcColourRgb);
-			shared_ptr<IfcColourRgb> color_rgb = dynamic_pointer_cast<IfcColourRgb>( color_spec );
-			if( color_rgb )
-			{
-				convertIfcColourRgb( color_rgb, color );
-			}
-			return;
-		}
-
-		shared_ptr<IfcPreDefinedColour> predefined_color = dynamic_pointer_cast<IfcPreDefinedColour>( ifc_color_select );
-		if( predefined_color )
-		{
-			// ENTITY IfcPreDefinedColour ABSTRACT SUPERTYPE OF(IfcDraughtingPreDefinedColour)
-			shared_ptr<IfcDraughtingPreDefinedColour> draughting_predefined_color = dynamic_pointer_cast<IfcDraughtingPreDefinedColour>( predefined_color );
-			if( draughting_predefined_color )
-			{
-				if( draughting_predefined_color->m_Name )
-				{
-					std::wstring predefined_name = draughting_predefined_color->m_Name->m_value;
-					if( boost::iequals( predefined_name, L"black" ) )			color.setColor( 0.0, 0.0, 0.0, 1.0 );
-					else if( boost::iequals( predefined_name, L"red" ) )		color.setColor( 1.0, 0.0, 0.0, 1.0 );
-					else if( boost::iequals( predefined_name, L"green" ) )		color.setColor( 0.0, 1.0, 0.0, 1.0 );
-					else if( boost::iequals( predefined_name, L"blue" ) )		color.setColor( 0.0, 0.0, 1.0, 1.0 );
-					else if( boost::iequals( predefined_name, L"yellow" ) )		color.setColor( 1.0, 1.0, 0.0, 1.0 );
-					else if( boost::iequals( predefined_name, L"magenta" ) )	color.setColor( 1.0, 0.0, 1.0, 1.0 );
-					else if( boost::iequals( predefined_name, L"cyan" ) )		color.setColor( 0.0, 1.0, 1.0, 1.0 );
-					else if( boost::iequals( predefined_name, L"white" ) )		color.setColor( 1.0, 1.0, 1.0, 1.0 );
-				}
-			}
-			return;
-		}
-	}
-
-
 	void convertIfcSurfaceStyle(
 		shared_ptr<IfcSurfaceStyle> const& surface_style,
 		shared_ptr<AppearanceData>& appearance_data )
@@ -561,6 +471,95 @@ public:
 		}
 
 		return;
+	}
+
+private:
+	void convertIfcSpecularHighlightSelect( shared_ptr<IfcSpecularHighlightSelect> highlight_select, shared_ptr<AppearanceData>& appearance_data )
+	{
+		if( dynamic_pointer_cast<IfcSpecularExponent>( highlight_select ) )
+		{
+			shared_ptr<IfcSpecularExponent> spec = dynamic_pointer_cast<IfcSpecularExponent>( highlight_select );
+			appearance_data->m_specular_exponent = spec->m_value;
+		}
+		else if( dynamic_pointer_cast<IfcSpecularRoughness>( highlight_select ) )
+		{
+			shared_ptr<IfcSpecularRoughness> specular_roughness = dynamic_pointer_cast<IfcSpecularRoughness>( highlight_select );
+			appearance_data->m_specular_roughness = specular_roughness->m_value;
+		}
+	}
+
+	void convertIfcColourRgb( shared_ptr<IfcColourRgb> color_rgb, vec4& color )
+	{
+		if( color_rgb->m_Red )
+		{
+			color.m_r = (float)color_rgb->m_Red->m_value;
+		}
+		if( color_rgb->m_Green )
+		{
+			color.m_g = (float)color_rgb->m_Green->m_value;
+		}
+		if( color_rgb->m_Blue )
+		{
+			color.m_b = (float)color_rgb->m_Blue->m_value;
+		}
+	}
+
+	void convertIfcColourOrFactor( shared_ptr<IfcColourOrFactor> color_or_factor, vec4& src_color, vec4& target_color )
+	{
+		// TYPE IfcColourOrFactor = SELECT ( IfcNormalisedRatioMeasure, IfcColourRgb);
+		shared_ptr<IfcColourRgb> color_rgb = dynamic_pointer_cast<IfcColourRgb>( color_or_factor );
+		if( color_rgb )
+		{
+			convertIfcColourRgb( color_rgb, target_color );
+			return;
+		}
+
+		shared_ptr<IfcNormalisedRatioMeasure> ratio_measure = dynamic_pointer_cast<IfcNormalisedRatioMeasure>( color_or_factor );
+		if( ratio_measure )
+		{
+			double factor = ratio_measure->m_value;
+			target_color.setColor( src_color.r()*factor, src_color.g()*factor, src_color.b()*factor, src_color.a() );
+			return;
+		}
+	}
+
+	void convertIfcColour( shared_ptr<IfcColour> ifc_color_select, vec4& color )
+	{
+		// IfcColour = SELECT ( IfcColourSpecification, IfcPreDefinedColour );
+		shared_ptr<IfcColourSpecification> color_spec = dynamic_pointer_cast<IfcColourSpecification>( ifc_color_select );
+		if( color_spec )
+		{
+			// ENTITY IfcColourSpecification ABSTRACT SUPERTYPE OF(IfcColourRgb);
+			shared_ptr<IfcColourRgb> color_rgb = dynamic_pointer_cast<IfcColourRgb>( color_spec );
+			if( color_rgb )
+			{
+				convertIfcColourRgb( color_rgb, color );
+			}
+			return;
+		}
+
+		shared_ptr<IfcPreDefinedColour> predefined_color = dynamic_pointer_cast<IfcPreDefinedColour>( ifc_color_select );
+		if( predefined_color )
+		{
+			// ENTITY IfcPreDefinedColour ABSTRACT SUPERTYPE OF(IfcDraughtingPreDefinedColour)
+			shared_ptr<IfcDraughtingPreDefinedColour> draughting_predefined_color = dynamic_pointer_cast<IfcDraughtingPreDefinedColour>( predefined_color );
+			if( draughting_predefined_color )
+			{
+				if( draughting_predefined_color->m_Name )
+				{
+					std::wstring predefined_name = draughting_predefined_color->m_Name->m_value;
+					if( boost::iequals( predefined_name, L"black" ) )			color.setColor( 0.0, 0.0, 0.0, 1.0 );
+					else if( boost::iequals( predefined_name, L"red" ) )		color.setColor( 1.0, 0.0, 0.0, 1.0 );
+					else if( boost::iequals( predefined_name, L"green" ) )		color.setColor( 0.0, 1.0, 0.0, 1.0 );
+					else if( boost::iequals( predefined_name, L"blue" ) )		color.setColor( 0.0, 0.0, 1.0, 1.0 );
+					else if( boost::iequals( predefined_name, L"yellow" ) )		color.setColor( 1.0, 1.0, 0.0, 1.0 );
+					else if( boost::iequals( predefined_name, L"magenta" ) )	color.setColor( 1.0, 0.0, 1.0, 1.0 );
+					else if( boost::iequals( predefined_name, L"cyan" ) )		color.setColor( 0.0, 1.0, 1.0, 1.0 );
+					else if( boost::iequals( predefined_name, L"white" ) )		color.setColor( 1.0, 1.0, 1.0, 1.0 );
+				}
+			}
+			return;
+		}
 	}
 
 	void convertIfcCurveStyle( shared_ptr<IfcCurveStyle> curve_style, shared_ptr<AppearanceData>& appearance_data )

--- a/IfcPlusPlus/src/ifcpp/geometry/StylesConverter.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/StylesConverter.h
@@ -168,28 +168,27 @@ public:
 	}
 
 
-	void convertIfcSurfaceStyle( shared_ptr<IfcSurfaceStyle> surface_style, shared_ptr<AppearanceData>& appearance_data )
+	void convertIfcSurfaceStyle(
+		shared_ptr<IfcSurfaceStyle> const& surface_style,
+		shared_ptr<AppearanceData>& appearance_data )
 	{
 		if( !surface_style )
-		{
 			return;
-		}
-		const int style_id = surface_style->m_entity_id;
+
+		auto const style_id = surface_style->m_entity_id;
 		auto it_find_existing_style = m_map_ifc_styles.find( style_id );
 		if( it_find_existing_style != m_map_ifc_styles.end() )
 		{
 			// todo: check if appearance compare is faster here
 			appearance_data = it_find_existing_style->second;
 			if( appearance_data->m_complete )
-			{
 				return;
-			}
 		}
 		else
 		{
 			if( !appearance_data )
 			{
-				appearance_data = shared_ptr<AppearanceData>( new AppearanceData( style_id ) );
+				appearance_data = std::make_shared<AppearanceData>(style_id);
 			}
 
 #ifdef ENABLE_OPENMP
@@ -199,27 +198,23 @@ public:
 		}
 		appearance_data->m_apply_to_geometry_type = AppearanceData::GEOM_TYPE_SURFACE;
 
-		std::vector<shared_ptr<IfcSurfaceStyleElementSelect> >& vec_styles = surface_style->m_Styles;
+		auto const& vec_styles = surface_style->m_Styles;
 		if( vec_styles.size() == 0 )
-		{
 			return;
-		}
 
-		for( size_t ii_styles = 0; ii_styles < vec_styles.size(); ++ii_styles )
+		for( auto const& surf_style_element_select : vec_styles )
 		{
-			shared_ptr<IfcSurfaceStyleElementSelect> surf_style_element_select = vec_styles[ii_styles];
 			if( !surf_style_element_select )
-			{
 				continue;
-			}
+
 			// TYPE IfcSurfaceStyleElementSelect = SELECT	(IfcExternallyDefinedSurfaceStyle	,IfcSurfaceStyleLighting	,IfcSurfaceStyleRefraction	,IfcSurfaceStyleShading	,IfcSurfaceStyleWithTextures);
-			shared_ptr<IfcSurfaceStyleShading> surface_style_shading = dynamic_pointer_cast<IfcSurfaceStyleShading>( surf_style_element_select );
+			auto const surface_style_shading = dynamic_pointer_cast<IfcSurfaceStyleShading>( surf_style_element_select );
 			if( surface_style_shading )
 			{
 				vec4 surface_color( 0.8, 0.82, 0.84, 1.0 );
 				if( surface_style_shading->m_SurfaceColour )
 				{
-					shared_ptr<IfcColourRgb> surf_color = surface_style_shading->m_SurfaceColour;
+					auto const& surf_color = surface_style_shading->m_SurfaceColour;
 					convertIfcColourRgb( surf_color, surface_color );
 				}
 
@@ -231,49 +226,44 @@ public:
 				vec4 ambient_color( surface_color );
 				vec4 diffuse_color( surface_color );
 				vec4 specular_color( surface_color );
-				double shininess = 35.f;
-				double transparency = surface_color.a();
-				bool set_transparent = false;
+				auto shininess = 35.;
+				auto transparency = surface_color.a();
+				auto set_transparent = false;
 
-				shared_ptr<IfcSurfaceStyleRendering> surf_style_rendering = dynamic_pointer_cast<IfcSurfaceStyleRendering>( surf_style_element_select );
+				if (surface_style_shading->m_Transparency)
+				{
+					// in IFC 1 is transparent, 0 is opaque. if not given, the value 0 (opaque) is assumed
+					// in osg, 1 is opaque, 0 is transparent
+					transparency = 1. - surface_style_shading->m_Transparency->m_value;
+					if (transparency < 0.1)
+						transparency = 0.1;
+
+					if (transparency > 1.)
+						transparency = 1.;
+
+					if (transparency < 0.99)
+						set_transparent = true;
+				}
+
+				auto const surf_style_rendering = dynamic_pointer_cast<IfcSurfaceStyleRendering>( surf_style_element_select );
 				if( surf_style_rendering )
 				{
 					if( surf_style_rendering->m_DiffuseColour )
 					{
-						shared_ptr<IfcColourOrFactor> color_or_factor = surf_style_rendering->m_DiffuseColour;
+						auto const& color_or_factor = surf_style_rendering->m_DiffuseColour;
 						convertIfcColourOrFactor( color_or_factor, surface_color, diffuse_color );
 					}
 
 					if( surf_style_rendering->m_SpecularColour )
 					{
-						shared_ptr<IfcColourOrFactor> ifc_specular_color = surf_style_rendering->m_SpecularColour;
+						auto const& ifc_specular_color = surf_style_rendering->m_SpecularColour;
 						convertIfcColourOrFactor( ifc_specular_color, surface_color, specular_color );
 					}
 
-					if( surf_style_rendering->m_Transparency )
-					{
-						// in IFC 1 is transparent, 0 is opaque. if not given, the value 0 (opaque) is assumed
-						// in osg, 1 is opaque, 0 is transparent
-						transparency = 1.f - (float)surf_style_rendering->m_Transparency->m_value;
-						if( transparency < 0.1f )
-						{
-							transparency = 0.1f;
-						}
-
-						if( transparency > 1.f )
-						{
-							transparency = 1.f;
-						}
-
-						if( transparency < 0.99f )
-						{
-							set_transparent = true;
-						}
-					}
 
 					if( surf_style_rendering->m_SpecularHighlight )
 					{
-						shared_ptr<IfcSpecularHighlightSelect> spec_highlight = surf_style_rendering->m_SpecularHighlight;
+						auto const& spec_highlight = surf_style_rendering->m_SpecularHighlight;
 						convertIfcSpecularHighlightSelect( spec_highlight, appearance_data );
 						shininess = appearance_data->m_specular_roughness * 128;
 						if( shininess <= 1.0 )
@@ -283,9 +273,21 @@ public:
 					}
 				}
 
-				appearance_data->m_color_ambient.setColor( ambient_color.r()*0.8, ambient_color.g()*0.8, ambient_color.b()*0.8, transparency );
-				appearance_data->m_color_diffuse.setColor( diffuse_color.r(), diffuse_color.g(), diffuse_color.b(), transparency );
-				appearance_data->m_color_specular.setColor( specular_color.r()*0.1, specular_color.g()*0.1, specular_color.b()*0.1, transparency );
+				appearance_data->m_color_ambient.setColor(
+					ambient_color.r()*0.8,
+					ambient_color.g()*0.8,
+					ambient_color.b()*0.8,
+					transparency );
+				appearance_data->m_color_diffuse.setColor(
+					diffuse_color.r(),
+					diffuse_color.g(),
+					diffuse_color.b(),
+					transparency );
+				appearance_data->m_color_specular.setColor(
+					specular_color.r()*0.1,
+					specular_color.g()*0.1,
+					specular_color.b()*0.1,
+					transparency );
 
 				appearance_data->m_shininess = shininess;
 				appearance_data->m_set_transparent = set_transparent;
@@ -294,7 +296,7 @@ public:
 				continue;
 			}
 
-			shared_ptr<IfcExternallyDefinedSurfaceStyle> ext_surf_style = dynamic_pointer_cast<IfcExternallyDefinedSurfaceStyle>( surf_style_element_select );
+			auto const ext_surf_style = dynamic_pointer_cast<IfcExternallyDefinedSurfaceStyle>( surf_style_element_select );
 			if( ext_surf_style )
 			{
 #ifdef _DEBUG
@@ -303,7 +305,7 @@ public:
 				continue;
 			}
 
-			shared_ptr<IfcSurfaceStyleLighting> style_lighting = dynamic_pointer_cast<IfcSurfaceStyleLighting>( surf_style_element_select );
+			auto const style_lighting = dynamic_pointer_cast<IfcSurfaceStyleLighting>( surf_style_element_select );
 			if( style_lighting )
 			{
 #ifdef _DEBUG
@@ -312,7 +314,7 @@ public:
 				continue;
 			}
 
-			shared_ptr<IfcSurfaceStyleRefraction> style_refraction = dynamic_pointer_cast<IfcSurfaceStyleRefraction>( surf_style_element_select );
+			auto const style_refraction = dynamic_pointer_cast<IfcSurfaceStyleRefraction>( surf_style_element_select );
 			if( style_refraction )
 			{
 #ifdef _DEBUG
@@ -321,7 +323,7 @@ public:
 				continue;
 			}
 
-			shared_ptr<IfcSurfaceStyleWithTextures> style_texture = dynamic_pointer_cast<IfcSurfaceStyleWithTextures>( surf_style_element_select );
+			auto const style_texture = dynamic_pointer_cast<IfcSurfaceStyleWithTextures>( surf_style_element_select );
 			if( style_texture )
 			{
 #ifdef _DEBUG


### PR DESCRIPTION
This pull request contains the following changes:
- Fix transparency import for IfcSurfaceStyleShading: Transparency was only read from SurfaceStyleRendering, although it is earlier available in SurfaceStyleShading
- Replace various variable declarations with auto. Makes the lines a bit shorter
- Declare functions only used inside the class as private
- Change out parameters to return statements in a few functions

If you only want the fix separately, I can put it in an isolated pull request.