### PR TITLE
Correct meshes when applying mirroring transformations

### DIFF
--- a/IfcPlusPlus/src/ifcpp/geometry/Carve/GeometryInputData.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/Carve/GeometryInputData.h
@@ -246,6 +246,14 @@ public:
 			}
 		}
 
+		//is negative if coordinate system changes handedness (for example as result of mirroring)
+		//in this case invert the meshes to not make them look inside out (only noticable if using
+		//back face culling)
+		bool const invert_meshes = 0 > carve::geom::dotcross(
+			carve::geom::VECTOR(mat.m[0][0], mat.m[1][0], mat.m[2][0]),
+			carve::geom::VECTOR(mat.m[0][1], mat.m[1][1], mat.m[2][1]),
+			carve::geom::VECTOR(mat.m[0][2], mat.m[1][2], mat.m[2][2]));
+
 		for( size_t i_meshsets = 0; i_meshsets < m_meshsets_open.size(); ++i_meshsets )
 		{
 			shared_ptr<carve::mesh::MeshSet<3> >& item_meshset = m_meshsets_open[i_meshsets];
@@ -258,6 +266,10 @@ public:
 			for( size_t i = 0; i < item_meshset->meshes.size(); ++i )
 			{
 				item_meshset->meshes[i]->recalc();
+				if(invert_meshes)
+				{
+					item_meshset->meshes[i]->invert();
+				}
 			}
 		}
 
@@ -273,6 +285,12 @@ public:
 			for( size_t i = 0; i < item_meshset->meshes.size(); ++i )
 			{
 				item_meshset->meshes[i]->recalc();
+				if(invert_meshes)
+				{
+					item_meshset->meshes[i]->invert();
+					//calcOrientation resets isNegative flag (usually)
+					item_meshset->meshes[i]->calcOrientation();
+				}
 			}
 		}
 


### PR DESCRIPTION
This is a visual bug I encountered under the following conditions:
- back face culling is used
- the model contains mapped items with mirroring transformations (this happens for my exports, as some objects originate from 3d modelling applications and contain arbitrary transformations)
The mirroring turns the meshes "inside out", meaning the face orientation is wrong.

This patch checks if such a transformation is applied and inverts the meshes in this case. Clearing the negative flag through calcOrientation is necessary as other functions later turn the meshes back if they are marked as negative. This is not necessary for open meshes as the negative flag is ignored by carve in this case.