### PR TITLE
Correct binary string delimiter

### DIFF
--- a/IfcPlusPlus/src/ifcpp/IFC4/lib/IfcBinary.cpp
+++ b/IfcPlusPlus/src/ifcpp/IFC4/lib/IfcBinary.cpp
@@ -23,7 +23,7 @@ shared_ptr<BuildingObject> IfcBinary::getDeepCopy( BuildingCopyOptions& options 
 void IfcBinary::getStepParameter( std::stringstream& stream, bool is_select_type ) const
 {
 	if( is_select_type ) { stream << "IFCBINARY("; }
-	stream << "'" << encodeStepString( m_value ) << "'";
+	stream << "\"" << encodeStepString( m_value ) << "\"";
 	if( is_select_type ) { stream << ")"; }
 }
 const std::wstring IfcBinary::toString() const

--- a/IfcPlusPlus/src/ifcpp/IFC4/lib/IfcBinary.cpp
+++ b/IfcPlusPlus/src/ifcpp/IFC4/lib/IfcBinary.cpp
@@ -35,6 +35,6 @@ shared_ptr<IfcBinary> IfcBinary::createObjectFromSTEP( const std::wstring& arg, 
 	if( arg.compare( L"$" ) == 0 ) { return shared_ptr<IfcBinary>(); }
 	else if( arg.compare( L"*" ) == 0 ) { return shared_ptr<IfcBinary>(); }
 	shared_ptr<IfcBinary> type_object( new IfcBinary() );
-	readString( arg, type_object->m_value );
+	readBinaryString( arg, type_object->m_value );
 	return type_object;
 }

--- a/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.h
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.h
@@ -190,6 +190,19 @@ inline void readString( const std::wstring& attribute_value, std::wstring& targe
 	}
 }
 
+inline void readBinaryString( const std::wstring& attribute_value, std::wstring& target )
+{
+	if( attribute_value.size() < 2 )
+	{
+		target = attribute_value;
+		return;
+	}
+	if( attribute_value[0] == '"' && attribute_value[attribute_value.size()-1] == '"' )
+	{
+		target = attribute_value.substr( 1, attribute_value.size()-2 );
+	}
+}
+
 template<typename T>
 void readTypeOfIntegerList( const std::wstring& str, std::vector<shared_ptr<T> >& target_vec )
 {


### PR DESCRIPTION
I noticed that the current implementation uses normal string delimiters (`'`) for entities of IfcBinary. The STEP spec uses double quotes for those (`"`).