### PR TITLE
Visual fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin32
 *.sdf
 SimpleViewerExample/dump_mesh_debug.txt
 *.opensdf
+/build/

--- a/examples/SimpleViewerExampleQt/src/gui/IfcTreeWidget.cpp
+++ b/examples/SimpleViewerExampleQt/src/gui/IfcTreeWidget.cpp
@@ -33,6 +33,8 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OU
 #include "IfcPlusPlusSystem.h"
 #include "IfcTreeWidget.h"
 
+#include <QHeaderView>
+
 QTreeWidgetItem* findItemByIfcId( QTreeWidgetItem* item, int ifc_id )
 {
 	int num_children = item->childCount();
@@ -63,8 +65,13 @@ IfcTreeWidget::IfcTreeWidget( IfcPlusPlusSystem* sys, QWidget* parent ) : QTreeW
 	setColumnWidth( 0, 100 );
 	setColumnWidth( 1, 60 );
 	setColumnWidth( 2, 60 );
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
+	header()->setSectionResizeMode(0, QHeaderView::Stretch);
+#else
+	header()->setResizeMode(0, QHeaderView::Stretch);
+#endif
 	setSelectionBehavior( QAbstractItemView::SelectRows );
-	setIndentation( 4 );
+	setIndentation( 12 );
 
 	connect( this, SIGNAL( currentItemChanged( QTreeWidgetItem*, QTreeWidgetItem* ) ), this, SLOT( slotTreewidgetSelectionChanged(QTreeWidgetItem*, QTreeWidgetItem*) ) );
 	connect( m_system, SIGNAL( signalObjectsSelected( std::map<int, shared_ptr<BuildingEntity> >&) ),	this, SLOT( slotObjectsSelected( std::map<int, shared_ptr<BuildingEntity> >&) ) );

--- a/examples/SimpleViewerExampleQt/src/gui/TabReadWrite.cpp
+++ b/examples/SimpleViewerExampleQt/src/gui/TabReadWrite.cpp
@@ -308,7 +308,8 @@ void TabReadWrite::slotLoadIfcFile( QString& path_in )
 
 void TabReadWrite::slotTxtOut( QString txt )
 {
-	m_txt_out->append( "<div style=\"color:black;\">" + txt.replace( "\n", "<br/>" ) + "</div><br/>" );
+	QString basecol = palette().text().color().name();
+	m_txt_out->append( "<div style=\"color:" + basecol + ";\">" + txt.replace( "\n", "<br/>" ) + "</div><br/>" );
 }
 
 void TabReadWrite::slotTxtOutWarning( QString txt )


### PR DESCRIPTION
Hi Fabian,

Here are a coupe of very small fixes to the SimpleViewer example app:
* Made the first column of the tree (the object name) stretchable, instead of the default (last one), as it is almost always the one that contains most text...
* Made the indent a little bit larger otherwise it "eats" the arrow... Apparently the value is in pixels...
* Used the system color for messages (in dark desktop themes black and white are often inverted)

I also added a "build" dir to gitignore so one can build in-source without polluting (most apps do that nowadays...)

Hope these changes are okay!

Cheers
Yorik