### PR TITLE
Make example compatible with OSG 3.2

### DIFF
--- a/examples/SimpleViewerExampleQt/src/viewer/GraphicsWindowQt.cpp
+++ b/examples/SimpleViewerExampleQt/src/viewer/GraphicsWindowQt.cpp
@@ -588,7 +588,7 @@ bool GraphicsWindowQt::realizeImplementation()
 
 	m_realized = true;
 
-  // make sure the event queue has the correct window rectangle size and input range
+	// make sure the event queue has the correct window rectangle size and input range
 #if (OPENSCENEGRAPH_MAJOR_VERSION == 3) && (OPENSCENEGRAPH_MINOR_VERSION == 2)
 	getEventQueue()->syncWindowRectangleWithGraphcisContext();
 #else

--- a/examples/SimpleViewerExampleQt/src/viewer/GraphicsWindowQt.cpp
+++ b/examples/SimpleViewerExampleQt/src/viewer/GraphicsWindowQt.cpp
@@ -15,6 +15,7 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTH
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include <osg/Version>
 #include <osgViewer/ViewerBase>
 #include <QInputEvent>
 #include <QOpenGLContext>
@@ -468,7 +469,11 @@ GraphicsWindowQt::GraphicsWindowQt( QWidget* parent, Qt::WindowFlags f )
 	}
 
 	// make sure the event queue has the correct window rectangle size and input range
+#if (OPENSCENEGRAPH_MAJOR_VERSION == 3) && (OPENSCENEGRAPH_MINOR_VERSION == 2)
+	getEventQueue()->syncWindowRectangleWithGraphcisContext();
+#else
 	getEventQueue()->syncWindowRectangleWithGraphicsContext();
+#endif
 }
 
 GraphicsWindowQt::~GraphicsWindowQt()
@@ -583,8 +588,12 @@ bool GraphicsWindowQt::realizeImplementation()
 
 	m_realized = true;
 
-	// make sure the event queue has the correct window rectangle size and input range
+  // make sure the event queue has the correct window rectangle size and input range
+#if (OPENSCENEGRAPH_MAJOR_VERSION == 3) && (OPENSCENEGRAPH_MINOR_VERSION == 2)
+	getEventQueue()->syncWindowRectangleWithGraphcisContext();
+#else
 	getEventQueue()->syncWindowRectangleWithGraphicsContext();
+#endif
 
 	// make this window's context not current
 	// note: this must be done as we will probably make the context current from another thread


### PR DESCRIPTION
On Ubuntu 16.04 and 18.04, `libopenscenegraph-dev` uses version 3.2 of `libopenscenegraph`, which has a typo in a member function name.

This PR checks which version of OSG the user is building against, and conditionally compiles the typoed versus fixed version of the function name. This should make it easier for users (especially on Ubuntu 16.04) to compile ifcplusplus without any errors.