### PR TITLE
Fix Ubuntu 18.04 QFileDialog

### DIFF
--- a/examples/SimpleViewerExampleQt/src/gui/TabReadWrite.cpp
+++ b/examples/SimpleViewerExampleQt/src/gui/TabReadWrite.cpp
@@ -394,7 +394,7 @@ void TabReadWrite::slotAddOtherIfcFileClicked()
 	{
 		default_dir = settings.value( "defaultDir" ).toString();
 	}
-	QString selected_file = QFileDialog::getOpenFileName(this, "Choose IFC file", default_dir );
+	QString selected_file = QFileDialog::getOpenFileName(this, "Choose IFC file", default_dir, QString(), Q_NULLPTR, QFileDialog::DontUseNativeDialog);
 	
 	if( !selected_file.isEmpty() )
 	{
@@ -407,7 +407,7 @@ void TabReadWrite::slotAddOtherIfcFileClicked()
 void TabReadWrite::slotSetWritePathClicked()
 {
 	QString selectedFilter;
-	QString fileName = QFileDialog::getSaveFileName(this, "IfcPlusPlus - choose path to write ifc file", m_le_path_write->text(), "All Files (*);;Text Files (*.ifc)", &selectedFilter);
+	QString fileName = QFileDialog::getSaveFileName(this, "IfcPlusPlus - choose path to write ifc file", m_le_path_write->text(), "All Files (*);;Text Files (*.ifc)", &selectedFilter, QFileDialog::DontUseNativeDialog);
 	if( !fileName.isEmpty() )
 	{
 		m_le_path_write->setText(fileName);

--- a/examples/SimpleViewerExampleQt/src/viewer/GraphicsWindowQt.cpp
+++ b/examples/SimpleViewerExampleQt/src/viewer/GraphicsWindowQt.cpp
@@ -588,7 +588,7 @@ bool GraphicsWindowQt::realizeImplementation()
 
 	m_realized = true;
 
-  // make sure the event queue has the correct window rectangle size and input range
+	// make sure the event queue has the correct window rectangle size and input range
 #if (OPENSCENEGRAPH_MAJOR_VERSION == 3) && (OPENSCENEGRAPH_MINOR_VERSION == 2)
 	getEventQueue()->syncWindowRectangleWithGraphcisContext();
 #else

--- a/examples/SimpleViewerExampleQt/src/viewer/GraphicsWindowQt.cpp
+++ b/examples/SimpleViewerExampleQt/src/viewer/GraphicsWindowQt.cpp
@@ -15,6 +15,7 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTH
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include <osg/Version>
 #include <osgViewer/ViewerBase>
 #include <QInputEvent>
 #include <QOpenGLContext>
@@ -468,7 +469,11 @@ GraphicsWindowQt::GraphicsWindowQt( QWidget* parent, Qt::WindowFlags f )
 	}
 
 	// make sure the event queue has the correct window rectangle size and input range
+#if (OPENSCENEGRAPH_MAJOR_VERSION == 3) && (OPENSCENEGRAPH_MINOR_VERSION == 2)
+	getEventQueue()->syncWindowRectangleWithGraphcisContext();
+#else
 	getEventQueue()->syncWindowRectangleWithGraphicsContext();
+#endif
 }
 
 GraphicsWindowQt::~GraphicsWindowQt()
@@ -583,8 +588,12 @@ bool GraphicsWindowQt::realizeImplementation()
 
 	m_realized = true;
 
-	// make sure the event queue has the correct window rectangle size and input range
+  // make sure the event queue has the correct window rectangle size and input range
+#if (OPENSCENEGRAPH_MAJOR_VERSION == 3) && (OPENSCENEGRAPH_MINOR_VERSION == 2)
+	getEventQueue()->syncWindowRectangleWithGraphcisContext();
+#else
 	getEventQueue()->syncWindowRectangleWithGraphicsContext();
+#endif
 
 	// make this window's context not current
 	// note: this must be done as we will probably make the context current from another thread


### PR DESCRIPTION
While running the `SimpleViewerExample` program on Ubuntu 18.04, the file selection dialog box seems to never open. It seems similar to an issue reported [here](https://groups.io/g/sdrangel/topic/serious_issues_with_ubuntu/18941988?p=,,,20,0,0,0::recentpostdate%2Fsticky,,,20,2,0,18941988).

The simplest fix was to pass in the `QFileDialog::DontUseNativeDialog` option to the file dialog box functions.

I don't know how this might affect other platforms, so I would recommend users on other platforms test out this change.

This PR builds on #112 because those changes were needed in order to compile.