### PR TITLE
Zoom to objects

### DIFF
--- a/examples/SimpleViewerExampleQt/src/IfcPlusPlusSystem.h
+++ b/examples/SimpleViewerExampleQt/src/IfcPlusPlusSystem.h
@@ -29,6 +29,7 @@ class ReaderSTEP;
 class WriterSTEP;
 class GeometryConverter;
 class CommandManager;
+class ViewerWidget;
 
 struct SelectedEntity 
 {
@@ -57,10 +58,12 @@ public:
 	osg::Switch*					getModelNode() { return m_sw_model; }
 	osg::Switch*					getCoordinateAxesNode() { return m_sw_coord_axes; }
 	void setRootNode( osg::Group* root );
+	void setViewerWidget( ViewerWidget* widget );
 	void toggleSceneLight();
 	void switchCurveRepresentation( osg::Group* grp, bool on_off );
 	
 	void setObjectSelected( shared_ptr<BuildingEntity> object, bool selected, osg::Group* node = 0 );
+	void zoomToObject( shared_ptr<BuildingEntity> object, osg::Group* node = 0 );
 	const std::map<int, shared_ptr<SelectedEntity> >& getSelectedObjects() { return m_map_selected; }
 	void clearSelection();
 	void notifyModelCleared();
@@ -68,6 +71,7 @@ public:
 	void notifyModelLoadingDone();
 
 private:
+	ViewerWidget*								m_viewer_widget;
 	shared_ptr<GeometryConverter>				m_geometry_converter;
 	shared_ptr<ReaderSTEP>						m_step_reader;
 	shared_ptr<WriterSTEP>						m_step_writer;

--- a/examples/SimpleViewerExampleQt/src/gui/IfcTreeWidget.cpp
+++ b/examples/SimpleViewerExampleQt/src/gui/IfcTreeWidget.cpp
@@ -74,6 +74,7 @@ IfcTreeWidget::IfcTreeWidget( IfcPlusPlusSystem* sys, QWidget* parent ) : QTreeW
 	setIndentation( 12 );
 
 	connect( this, SIGNAL( currentItemChanged( QTreeWidgetItem*, QTreeWidgetItem* ) ), this, SLOT( slotTreewidgetSelectionChanged(QTreeWidgetItem*, QTreeWidgetItem*) ) );
+	connect( this, SIGNAL( itemDoubleClicked( QTreeWidgetItem*, int )), this, SLOT(slotTreeWidgetItemDoubleClick(QTreeWidgetItem*, int)));
 	connect( m_system, SIGNAL( signalObjectsSelected( std::map<int, shared_ptr<BuildingEntity> >&) ),	this, SLOT( slotObjectsSelected( std::map<int, shared_ptr<BuildingEntity> >&) ) );
 	connect( m_system, SIGNAL( signalModelCleared() ),		this, SLOT( slotModelCleared() ) );
 	connect( m_system, SIGNAL( signalModelLoadingStart() ),	this, SLOT( slotModelLoadingStart() ) );
@@ -153,6 +154,32 @@ void IfcTreeWidget::slotTreewidgetSelectionChanged( QTreeWidgetItem* current, QT
 void IfcTreeWidget::slotTreewidgetSelectionChanged()
 {
 
+}
+
+void IfcTreeWidget::slotTreeWidgetItemDoubleClick( QTreeWidgetItem* item, int column )
+{
+	if( m_block_selection_signals )
+	{
+		return;
+	}
+
+	if( !item )
+	{
+		return;
+	}
+
+	const std::map<int,shared_ptr<BuildingEntity>>& map_ifc_objects = m_system->getIfcModel()->getMapIfcEntities();
+	const int id = item->text(1).toUInt();
+	const std::map<int,shared_ptr<BuildingEntity>>::const_iterator it_find = map_ifc_objects.find(id);
+
+	if( it_find == map_ifc_objects.end() )
+	{
+		return;
+	}
+
+	m_block_selection_signals = true;
+	m_system->zoomToObject(it_find->second);
+	m_block_selection_signals = false;
 }
 
 void IfcTreeWidget::slotModelCleared()

--- a/examples/SimpleViewerExampleQt/src/gui/IfcTreeWidget.h
+++ b/examples/SimpleViewerExampleQt/src/gui/IfcTreeWidget.h
@@ -39,6 +39,7 @@ public slots:
 	void slotObjectsSelected( std::map<int, shared_ptr<BuildingEntity> >& map );
 	void slotTreewidgetSelectionChanged( QTreeWidgetItem* current, QTreeWidgetItem* previous );
 	void slotTreewidgetSelectionChanged();
+	void slotTreeWidgetItemDoubleClick( QTreeWidgetItem* item, int column );
 
 	void slotModelCleared();
 	void slotModelLoadingStart();

--- a/examples/SimpleViewerExampleQt/src/gui/TabReadWrite.cpp
+++ b/examples/SimpleViewerExampleQt/src/gui/TabReadWrite.cpp
@@ -394,7 +394,7 @@ void TabReadWrite::slotAddOtherIfcFileClicked()
 	{
 		default_dir = settings.value( "defaultDir" ).toString();
 	}
-	QString selected_file = QFileDialog::getOpenFileName(this, "Choose IFC file", default_dir );
+	QString selected_file = QFileDialog::getOpenFileName(this, "Choose IFC file", default_dir, QString(), Q_NULLPTR, QFileDialog::DontUseNativeDialog);
 	
 	if( !selected_file.isEmpty() )
 	{
@@ -407,7 +407,7 @@ void TabReadWrite::slotAddOtherIfcFileClicked()
 void TabReadWrite::slotSetWritePathClicked()
 {
 	QString selectedFilter;
-	QString fileName = QFileDialog::getSaveFileName(this, "IfcPlusPlus - choose path to write ifc file", m_le_path_write->text(), "All Files (*);;Text Files (*.ifc)", &selectedFilter);
+	QString fileName = QFileDialog::getSaveFileName(this, "IfcPlusPlus - choose path to write ifc file", m_le_path_write->text(), "All Files (*);;Text Files (*.ifc)", &selectedFilter, QFileDialog::DontUseNativeDialog);
 	if( !fileName.isEmpty() )
 	{
 		m_le_path_write->setText(fileName);

--- a/examples/SimpleViewerExampleQt/src/viewer/GraphicsWindowQt.cpp
+++ b/examples/SimpleViewerExampleQt/src/viewer/GraphicsWindowQt.cpp
@@ -588,7 +588,7 @@ bool GraphicsWindowQt::realizeImplementation()
 
 	m_realized = true;
 
-  // make sure the event queue has the correct window rectangle size and input range
+	// make sure the event queue has the correct window rectangle size and input range
 #if (OPENSCENEGRAPH_MAJOR_VERSION == 3) && (OPENSCENEGRAPH_MINOR_VERSION == 2)
 	getEventQueue()->syncWindowRectangleWithGraphcisContext();
 #else

--- a/examples/SimpleViewerExampleQt/src/viewer/GraphicsWindowQt.cpp
+++ b/examples/SimpleViewerExampleQt/src/viewer/GraphicsWindowQt.cpp
@@ -15,6 +15,7 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTH
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+#include <osg/Version>
 #include <osgViewer/ViewerBase>
 #include <QInputEvent>
 #include <QOpenGLContext>
@@ -468,7 +469,11 @@ GraphicsWindowQt::GraphicsWindowQt( QWidget* parent, Qt::WindowFlags f )
 	}
 
 	// make sure the event queue has the correct window rectangle size and input range
+#if (OPENSCENEGRAPH_MAJOR_VERSION == 3) && (OPENSCENEGRAPH_MINOR_VERSION == 2)
+	getEventQueue()->syncWindowRectangleWithGraphcisContext();
+#else
 	getEventQueue()->syncWindowRectangleWithGraphicsContext();
+#endif
 }
 
 GraphicsWindowQt::~GraphicsWindowQt()
@@ -583,8 +588,12 @@ bool GraphicsWindowQt::realizeImplementation()
 
 	m_realized = true;
 
-	// make sure the event queue has the correct window rectangle size and input range
+  // make sure the event queue has the correct window rectangle size and input range
+#if (OPENSCENEGRAPH_MAJOR_VERSION == 3) && (OPENSCENEGRAPH_MINOR_VERSION == 2)
+	getEventQueue()->syncWindowRectangleWithGraphcisContext();
+#else
 	getEventQueue()->syncWindowRectangleWithGraphicsContext();
+#endif
 
 	// make this window's context not current
 	// note: this must be done as we will probably make the context current from another thread

--- a/examples/SimpleViewerExampleQt/src/viewer/ViewerWidget.cpp
+++ b/examples/SimpleViewerExampleQt/src/viewer/ViewerWidget.cpp
@@ -40,6 +40,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OU
 ViewerWidget::ViewerWidget( IfcPlusPlusSystem* sys, QWidget* parent ) : QWidget( parent )
 {
 	m_system = sys;
+	m_system->setViewerWidget(this);
 	m_parent = parent;
 	m_shinyness = 35.0;
 	m_material_default = new osg::Material();


### PR DESCRIPTION
This PR adds the ability to have the OSG viewer in the `SimpleViewerExample` zoom into an object when you double-click its entry in the tree widget. I found this very useful when looking at an extremely large scale IFC file.

This PR builds on #112 and #113, because I needed those changes in order for the `SimpleViewerExample` to work at all on my platform (Ubuntu 18.04). Technically the changes that are unique to this PR could be split into their own independent PR, but I wouldn't be able to test it on my machine if that was done.