### PR TITLE
encodes apostrophe in 'encodeStepString(..)'

### DIFF
--- a/IfcPlusPlus/src/ifcpp/writer/WriterUtil.cpp
+++ b/IfcPlusPlus/src/ifcpp/writer/WriterUtil.cpp
@@ -46,6 +46,11 @@ std::string encodeStepString( const std::wstring& str )
 			// encode carriage return
 			result_str.append( "\\X\\0D" );
 		}
+		else if( append_char == 39 )
+		{
+			// encode apostrophe
+			result_str.append( "\\X\\27" );
+		}
 		else if( append_char == 92 )
 		{
 			// encode backslash


### PR DESCRIPTION
If the string delimiter (') isn't encoded, an apostrophe in a step string interferes with the string delimiter and thus results in a bad ifc-file.