### PR TITLE
Added geometry setting controlling the number of points per spline

### DIFF
--- a/IfcPlusPlus/src/ifcpp/geometry/Carve/RepresentationConverter.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/Carve/RepresentationConverter.h
@@ -87,7 +87,7 @@ public:
 	{
 		m_styles_converter = shared_ptr<StylesConverter>( new StylesConverter() );
 		m_point_converter = shared_ptr<PointConverter>( new PointConverter( m_unit_converter ) );
-		m_spline_converter = shared_ptr<SplineConverter>( new SplineConverter( m_point_converter ) );
+		m_spline_converter = shared_ptr<SplineConverter>( new SplineConverter( m_geom_settings, m_point_converter ) );
 		m_sweeper = shared_ptr<Sweeper>( new Sweeper( m_geom_settings, m_unit_converter ) );
 		m_placement_converter = shared_ptr<PlacementConverter>( new PlacementConverter( m_unit_converter ) );
 		m_curve_converter = shared_ptr<CurveConverter>( new CurveConverter( m_geom_settings, m_placement_converter, m_point_converter, m_spline_converter ) );

--- a/IfcPlusPlus/src/ifcpp/geometry/Carve/SplineConverter.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/Carve/SplineConverter.h
@@ -17,6 +17,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OU
 
 #pragma once
 
+#include <ifcpp/geometry/GeometrySettings.h>
 #include <ifcpp/model/BasicTypes.h>
 #include <ifcpp/model/StatusCallback.h>
 
@@ -33,9 +34,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OU
 
 class SplineConverter : public StatusCallback
 {
-public:
+protected:
+	shared_ptr<GeometrySettings> m_geom_settings;
 	shared_ptr<PointConverter> m_point_converter;
 
+public:
 	static void computeKnotVector( const size_t num_ctrl_points, const size_t order, std::vector<double>& knot_vec )
 	{
 		const size_t n_plus_order = num_ctrl_points + order;
@@ -203,9 +206,11 @@ public:
 		}
 	}
 
-	SplineConverter( shared_ptr<PointConverter>& pt_converter ) : m_point_converter( pt_converter )
+	SplineConverter( shared_ptr<GeometrySettings>& geom_settings, shared_ptr<PointConverter>& pt_converter )
+		: m_geom_settings( geom_settings ), m_point_converter( pt_converter )
 	{
 	}
+
 	virtual ~SplineConverter()
 	{
 	}
@@ -239,7 +244,7 @@ public:
 
 		const size_t num_control_pts = vec_control_points.size();
 		const size_t order = degree + 1; // the order of the curve is the degree of the resulting polynomial + s1
-		const size_t num_curve_pts = num_control_pts * 4;  // TODO: make this ajustable
+		const size_t num_curve_pts = num_control_pts * m_geom_settings->getNumVerticesPerControlPoint();
 		std::vector<double> knot_vec;
 
 		//	set weighting factors to 1.0 in case of homogenious curve

--- a/IfcPlusPlus/src/ifcpp/geometry/GeometrySettings.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/GeometrySettings.h
@@ -60,11 +60,21 @@ public:
 	{
 		m_min_num_vertices_per_arc = 6;
 	}
-
 	void setMinNumVerticesPerArc( int num )
 	{
 		m_min_num_vertices_per_arc = num;
 	}
+
+	int getNumVerticesPerControlPoint() { return m_num_vertices_per_control_point; }
+	void setNumVerticesPerControlPoint( int num )
+	{
+		m_num_vertices_per_control_point = num;
+	}
+	void resetNumVerticesPerControlPoint()
+	{
+		m_num_vertices_per_control_point = m_num_vertices_per_control_point_default;
+	}
+
 	void setHandleLayerAssignments( bool handle ) { m_handle_layer_assignments = handle; }
 	bool handleLayerAssignments() { return m_handle_layer_assignments; }
 	
@@ -105,6 +115,8 @@ protected:
 	int	m_num_vertices_per_circle = 14;
 	int m_num_vertices_per_circle_default = 14;
 	int m_min_num_vertices_per_arc = 6;
+	int m_num_vertices_per_control_point = 4;
+	int m_num_vertices_per_control_point_default = 4;
 	bool m_show_text_literals = false;
 	bool m_ignore_profile_radius = false;
 	bool m_handle_styled_items = true;

--- a/IfcPlusPlus/src/ifcpp/geometry/OCC/RepresentationConverterOCC.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/OCC/RepresentationConverterOCC.h
@@ -80,7 +80,7 @@ public:
 		: m_geom_settings( geom_settings ), m_unit_converter( unit_converter )
 	{
 		m_styles_converter = shared_ptr<StylesConverter>( new StylesConverter() );
-		m_spline_converter = shared_ptr<SplineConverterOCC>( new SplineConverterOCC() );
+		m_spline_converter = shared_ptr<SplineConverterOCC>( new SplineConverterOCC( m_geom_settings ) );
 		m_curve_converter = shared_ptr<CurveConverterOCC>( new CurveConverterOCC( m_geom_settings, m_unit_converter, m_spline_converter ) );
 		m_profile_cache = shared_ptr<ProfileCacheOCC>( new ProfileCacheOCC( m_curve_converter, m_spline_converter ) );
 		m_face_converter = shared_ptr<FaceConverterOCC>( new FaceConverterOCC( m_geom_settings, m_unit_converter, m_curve_converter, m_spline_converter ) );

--- a/IfcPlusPlus/src/ifcpp/geometry/OCC/SplineConverterOCC.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/OCC/SplineConverterOCC.h
@@ -17,6 +17,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OU
 
 #pragma once
 
+#include <ifcpp/geometry/GeometrySettings.h>
 #include <ifcpp/model/BasicTypes.h>
 #include <ifcpp/model/StatusCallback.h>
 
@@ -32,6 +33,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OU
 class SplineConverterOCC : public StatusCallback
 {
 public:
+	shared_ptr<GeometrySettings> m_geom_settings;
 
 	static void computeKnotVector( const size_t num_ctrl_points, const size_t order, std::vector<double>& knot_vec )
 	{
@@ -200,7 +202,10 @@ public:
 		}
 	}
 
-	SplineConverterOCC(){}
+	SplineConverterOCC( const shared_ptr<GeometrySettings>& gs ) : m_geom_settings( gs )
+	{
+	}
+
 	virtual ~SplineConverterOCC(){}
 
 	void convertBSplineCurve( const shared_ptr<IfcBSplineCurve>& bspline_curve, TopoDS_Wire& /*target_wire*/, double length_factor ) const
@@ -232,7 +237,7 @@ public:
 
 		const size_t num_control_pts = vec_control_points.size();
 		const size_t order = degree + 1; // the order of the curve is the degree of the resulting polynomial + s1
-		const size_t num_curve_pts = num_control_pts * 4;  // TODO: make this ajustable
+		const size_t num_curve_pts = num_control_pts * m_geom_settings->getNumVerticesPerControlPoint();
 		std::vector<double> knot_vec;
 
 		//	set weighting factors to 1.0 in case of homogenious curve


### PR DESCRIPTION
Moves the hard-coded factor of 4 curve points per control point of the spline out into `GeometrySettings`, and exposes it.