### PR TITLE
migrated from deprecated std::bind2nd to std:bind

### DIFF
--- a/external/Carve/src/include/carve/mesh_simplify.hpp
+++ b/external/Carve/src/include/carve/mesh_simplify.hpp
@@ -1432,7 +1432,7 @@ class MeshSimplifier {
     meshset->meshes.erase(
         std::remove_if(
             meshset->meshes.begin(), meshset->meshes.end(),
-            std::bind2nd(std::equal_to<mesh_t*>(), (mesh_t*)nullptr)),
+            std::bind(std::equal_to<mesh_t*>(), std::placeholders::_1, (mesh_t*)nullptr)),
         meshset->meshes.end());
     return n_removed;
   }


### PR DESCRIPTION
The deprecated std::bind2nd creates the following error with Visual C++ 17 compiler:
`error C2039: 'bind2nd': is not a member of 'std'`
I tested my fix with both Visual C++ 17 and gcc 5.4.0.