### PR TITLE
removed use of std::iterator which is deprecated in C++17

### DIFF
--- a/external/Carve/src/include/carve/mesh.hpp
+++ b/external/Carve/src/include/carve/mesh.hpp
@@ -731,10 +731,12 @@ class MeshSet {
 
  public:
   template <typename face_type>
-  struct FaceIter
-      : public std::iterator<std::random_access_iterator_tag, face_type> {
-    typedef std::iterator<std::random_access_iterator_tag, face_type> super;
-    typedef typename super::difference_type difference_type;
+  struct FaceIter {
+    typedef std::random_access_iterator_tag iterator_category;
+    typedef face_type value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef face_type* pointer;
+    typedef face_type& reference;
 
     const MeshSet<ndim>* obj;
     size_t mesh, face;


### PR DESCRIPTION
This was causing the following warning on client side, with Visual C++ 2017:
`warning C4996: 'std::iterator<std::random_access_iterator_tag,face_type,ptrdiff_t,_Ty *,_Ty &>::iterator_category': warning STL4015: The std::iterator class template (used as a base class to provide typedefs) is deprecated in C++17. (The <iterator> header is NOT deprecated.) The C++ Standard has never required user-defined iterators to derive from std::iterator. To fix this warning, stop deriving from std::iterator and start providing publicly accessible typedefs named iterator_category, value_type, difference_type, pointer, and reference. Note that value_type is required to be non-const, even for constant iterators.`