### PR TITLE
Add a Dockerfile to make Linux builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+    apt-get install -y software-properties-common cmake libboost1.62-dev && \
+    add-apt-repository ppa:ubuntu-toolchain-r/test && \
+    apt-get install -y g++-8 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-8 


### PR DESCRIPTION
Using this `Dockerfile`, one can easily make a Linux build using the two following commands:

```bash
# First, create the Docker container image. This has to be done only once.
docker build . -t ifcplusplus
# Then, use Docker to make the build.
docker run --rm -it -v $PWD:$PWD -w $PWD ifcplusplus bash -c "mkdir -p build && cd build && cmake .. -DBUILD_VIEWER_APPLICATION=OFF && make -j8"
```

It works only for the lib for now. But I guess we could at QT5 to the Docker container image and then be able to build everything.

Wiki should probably updated to feature this too.