### PR TITLE
ReaderSTEP: Try to use en_us.UTF-8 and en_US.utf8 if en-US fails.

### DIFF
--- a/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
@@ -76,7 +76,7 @@ void ReaderSTEP::loadModelFromFile( const std::wstring& filePath, shared_ptr<Bui
 	}
 
 	// open file
-	if( !setlocale(LC_ALL, "en-US") )
+	if( !(setlocale(LC_ALL, "en-US") || setlocale(LC_ALL, "en_us.UTF-8") ||  setlocale(LC_ALL, "en_US.utf8")))
 	{
 		std::wstringstream strs;
 		strs << L"setlocale failed" << std::endl;


### PR DESCRIPTION
Some systems use `en_us.UTF-8` or `en_US.utf8` instead of `en-US`.