### PR TITLE
Fix for-loop condition statement.

### DIFF
--- a/IfcPlusPlus/src/ifcpp/model/BuildingGuid.h
+++ b/IfcPlusPlus/src/ifcpp/model/BuildingGuid.h
@@ -104,7 +104,7 @@ inline boost::uuids::uuid decodeBase64Uuid(std::basic_string<T> const& input)
 		return 0;
 	};
 	//4 input characters will be decoded to 3 output byte
-	for (size_t i = 0, j = 0; i < in_stop, j < out_stop; ++i)
+	for (size_t i = 0, j = 0; i < in_stop && j < out_stop; ++i)
 	{
 		uuid.data[j] = index_of(input[i]) << 2;
 		if(in_stop <= ++i) break;


### PR DESCRIPTION
In the old version (`i < in_stop, j < out_stop`), only the last part `j < out_stop` has any effect.

```
ifcplusplus/IfcPlusPlus/src/ifcpp/model/BuildingGuid.h:107:30: warning: relational comparison result unused
      [-Wunused-comparison]
        for (size_t i = 0, j = 0; i < in_stop, j < out_stop; ++i)
                                  ~~^~~~~~~~~
```