### PR TITLE
HEADER and ENDSEC added for the header section

### DIFF
--- a/IfcPlusPlus/src/ifcpp/writer/WriterSTEP.cpp
+++ b/IfcPlusPlus/src/ifcpp/writer/WriterSTEP.cpp
@@ -39,7 +39,9 @@ void WriterSTEP::writeModelToStream( std::stringstream& stream, shared_ptr<Build
 	const std::wstring& file_header_wstr = model->getFileHeader();
 	std::string file_header_str = ws2s( file_header_wstr );
 	stream << "ISO-10303-21;\n" << std::endl;
+	stream << "HEADER;\n";
 	stream << file_header_str.c_str();
+	stream << "ENDSEC;\n";
 	stream << "DATA;\n";
 	stream << std::setprecision( 15 );
 	stream << std::setiosflags( std::ios::showpoint );


### PR DESCRIPTION
Changes in: WriterSTEP
When reading previously saved .ifc files without any modifications we noticed that something went wrong. When we read the code in WriterSTEP we noticed that, although the data section is surrounded by the DATA and ENDSEC tags, this didn't happen to the header.

After consulting the standard for the header we saw that it also should be surrounded by these tags, and that's the little modification proposed here.