### PR TITLE
Add render object filter in GeometrySettings

### DIFF
--- a/IfcPlusPlus/src/ifcpp/geometry/Carve/GeometryConverter.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/Carve/GeometryConverter.h
@@ -319,7 +319,7 @@ public:
 				product_geom_input_data->m_ifc_object_definition = ifc_object_def;
 
 				std::stringstream thread_err;
-				if( dynamic_pointer_cast<IfcFeatureElementSubtraction>(ifc_object_def) )
+				if( !m_geom_settings->getRenderObjectFilter()(ifc_object_def) )
 				{
 					// geometry will be created in method subtractOpenings
 					continue;
@@ -441,7 +441,7 @@ public:
 					{
 						shared_ptr<IfcObjectDefinition> ifc_product( product_shape->m_ifc_object_definition );
 						shared_ptr<IfcFeatureElementSubtraction> opening = dynamic_pointer_cast<IfcFeatureElementSubtraction>(ifc_product);
-						if( opening )
+						if( !m_geom_settings->getRenderObjectFilter()(ifc_product) )
 						{
 							continue;
 						}

--- a/IfcPlusPlus/src/ifcpp/geometry/GeometrySettings.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/GeometrySettings.h
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OU
 #include <cmath>
 #include <ifcpp/model/OpenMPIncludes.h>
 #include <functional>
+#include <ifcpp/IFC4/include/IfcFeatureElementSubtraction.h>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -124,6 +125,19 @@ public:
 	bool getRenderBoundingBoxes() { return m_render_bounding_box; }
 	void setRenderBoundingBoxes( bool render_bbox ) { m_render_bounding_box = render_bbox; }
 
+        /**\brief Render filter decides if a IfcObjectDefinition should be
+        rendered. The default filter will render all objects except objects
+        based on IfcFeatureElementSubtraction.*/
+        std::function<bool(const shared_ptr<IfcObjectDefinition> &)>
+        getRenderObjectFilter() const {
+          return m_render_object_filter;
+        };
+        void setRenderObjectFilter(
+            std::function<bool(const shared_ptr<IfcObjectDefinition> &)>
+                render_filter) {
+          m_render_object_filter = std::move(render_filter);
+        };
+
 protected:
 	int	m_num_vertices_per_circle = 14;
 	int m_num_vertices_per_circle_default = 14;
@@ -139,4 +153,9 @@ protected:
 	double m_crease_edges_max_delta_angle = M_PI*0.05;
 	double m_colinear_faces_max_delta_angle = M_PI*0.02;
 	std::function<int(double)> m_num_vertices_per_circle_given_radius = [&](double radius) {return m_num_vertices_per_circle;};
+	std::function<bool(const shared_ptr<IfcObjectDefinition> &)> m_render_object_filter =
+			[](const shared_ptr<IfcObjectDefinition> &ifc_object) {
+				return dynamic_pointer_cast<IfcFeatureElementSubtraction>(ifc_object) ==
+					nullptr;
+			};
 };


### PR DESCRIPTION
It is useful to extract only openings from the IFC.
This new setting makes that possible and gives the user even more flexibility. The user may, for example, choose to only extract walls.