### PR TITLE
Fix Cmake Build

### DIFF
--- a/IfcPlusPlus/CMakeLists.txt
+++ b/IfcPlusPlus/CMakeLists.txt
@@ -35,6 +35,7 @@ SET(IFCPP_SOURCE_FILES
   src/ifcpp/reader/ReaderUtil.cpp
   src/ifcpp/writer/WriterSTEP.cpp
   src/ifcpp/writer/WriterUtil.cpp
+  src/external/XUnzip.cpp
 
   ${ifc4_source}
 )


### PR DESCRIPTION
In the main IfcPlusPlus CMakelist, the file XUnzip.cpp is missing in source list.