### PR TITLE
Small fixes for CMake + visual c++ compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,8 @@ ADD_SUBDIRECTORY (IfcPlusPlus)
 
 # Install configuration file
 INCLUDE(CMakePackageConfigHelpers)
-SET(config_file_input  "${CMAKE_SOURCE_DIR}/cmake/IFCPPConfig.cmake.in")
-SET(config_file_output "${CMAKE_BINARY_DIR}/cmake/IFCPPConfig.cmake")
+SET(config_file_input  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/IFCPPConfig.cmake.in")
+SET(config_file_output "${CMAKE_CURRENT_BINARY_DIR}/cmake/IFCPPConfig.cmake")
 
 CONFIGURE_PACKAGE_CONFIG_FILE(
   ${config_file_input}

--- a/external/Carve/src/lib/mesh.cpp
+++ b/external/Carve/src/lib/mesh.cpp
@@ -33,6 +33,10 @@
 #include <carve/poly.hpp>
 #include <functional>
 
+#if defined(_MSC_VER)
+inline int random() { return rand(); }
+#endif
+
 namespace {
 inline double CALC_X(const carve::geom::plane<3>& p, double y, double z) {
   return -(p.d + p.N.y * y + p.N.z * z) / p.N.x;

--- a/external/Carve/src/lib/polyhedron.cpp
+++ b/external/Carve/src/lib/polyhedron.cpp
@@ -44,6 +44,10 @@
 #include <carve/mesh.hpp>
 #include <random>
 
+#if defined(_MSC_VER)
+inline int random() { return rand(); }
+#endif
+
 namespace {
 bool emb_test(carve::poly::Polyhedron* poly,
               std::map<int, std::set<int> >& embedding, carve::geom3d::Vector v,


### PR DESCRIPTION
Replaced  CMAKE_SOURCE_DIR by CMAKE_CURRENT_SOURCE_DIR (and the same with BINARY) to be able to call CMakeLists.txt from another with add_subdirectory.
Small fixes in Carve as random() is not defined in Visual C++