### PR TITLE
Removed non-unicode degree symbol from comments in UnitConverter.cpp.

### DIFF
--- a/IfcPlusPlus/src/ifcpp/model/UnitConverter.cpp
+++ b/IfcPlusPlus/src/ifcpp/model/UnitConverter.cpp
@@ -69,7 +69,7 @@ void UnitConverter::resetUnitFactors()
 	}
 	else if( m_angular_unit == DEGREE )
 	{
-		m_plane_angle_factor = M_PI/180.0; // 360°
+		m_plane_angle_factor = M_PI/180.0; // 360 degrees
 	}
 	else if( m_angular_unit == GON )
 	{
@@ -92,7 +92,7 @@ void UnitConverter::setAngleUnit(AngularUnit unit)
 	}
 	else if( m_angular_unit == DEGREE )
 	{
-		m_plane_angle_factor = M_PI / 180.0; // 360°
+		m_plane_angle_factor = M_PI / 180.0; // 360 degrees
 	}
 	else if( m_angular_unit == GON )
 	{


### PR DESCRIPTION
If you compile with the /utf-8 option in MSVC, this symbol will cause a warning
to be thrown up because it's not encoded with utf8. There's probably a
way to force it to be encoded as utf8, but it's easier to just use the
word "degrees".