### PR TITLE
Fixed bug where file paths with unicode characters couldn't be opened. Fixes #173

### DIFF
--- a/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
@@ -139,10 +139,15 @@ void ReaderSTEP::loadModelFromFile( const std::wstring& filePath, shared_ptr<Bui
 	}
 
 	// open file
+	std::ifstream infile;
+
+#ifdef _MSC_VER
+	infile.open(filePath);
+#else
 	std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> StringConverter;
 	std::string filePathStr = StringConverter.to_bytes(filePath);
 
-	if( !(setlocale(LC_ALL, "en-US") || setlocale(LC_ALL, "en_us.UTF-8") ||  setlocale(LC_ALL, "en_US.utf8")))
+	if( !(setlocale(LC_ALL,"English_United States.65001") || setlocale(LC_ALL, "en-US")) )
 	{
 		std::wstringstream strs;
 		strs << L"setlocale failed" << std::endl;
@@ -157,8 +162,10 @@ void ReaderSTEP::loadModelFromFile( const std::wstring& filePath, shared_ptr<Bui
 		filePathStr = buf;
 		delete[] buf;
 	}
-	std::ifstream infile(filePathStr.c_str(), std::ifstream::in);
-	
+	infile.open(filePathStr.c_str(), std::ifstream::in);
+
+#endif
+
 	if( !infile.is_open() )
 	{
 		std::wstringstream strs;


### PR DESCRIPTION
I'm not sure this is the best way to approach the problem, but it's the best I could come up with. What's going on is that Windows provides a special overload of `std::ifstream::open()` that takes a `std::wstring` for the file path.

The other change is to use `"English_United States.65001"` as the default locale, using the UTF-8 codepage. This is, according to the documentation, the correct syntax: https://docs.microsoft.com/en-us/cpp/c-runtime-library/locale-names-languages-and-country-region-strings?view=vs-2019. As a fallback, it uses the previous "en-US" locale.