### PR TITLE
Fix build with msvc2015 upd3, flag /std:c++latest enabled

### DIFF
--- a/IfcPlusPlus/src/ifcpp/model/BasicTypes.h
+++ b/IfcPlusPlus/src/ifcpp/model/BasicTypes.h
@@ -20,7 +20,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OU
 #if _MSC_VER >= 1600
 
 #include <memory>
-#if _MSC_VER < 1912
+#if _MSC_VER < 1900
 using std::tr1::shared_ptr;
 using std::tr1::weak_ptr;
 using std::tr1::dynamic_pointer_cast;


### PR DESCRIPTION
STD library of msvc2015 defines all types from memory file in std namespace, tr1 nested namespace aliases are enabled by _HAS_TR1_NAMESPACE macro for backward compatibility. So there is no reason to use aliases form tr1 in msvc2015 (ver 1900).