### PR TITLE
New SVG icons for IFC++, and make sure they are included in Linux

### DIFF
--- a/examples/SimpleViewerExampleQt/CMakeLists.txt
+++ b/examples/SimpleViewerExampleQt/CMakeLists.txt
@@ -20,6 +20,10 @@ FIND_PACKAGE(Qt5Widgets REQUIRED)
 FIND_PACKAGE(Qt5OpenGL REQUIRED)
 ADD_DEFINITIONS(${Qt5Widgets_DEFINITIONS})
 
+SET(viewer_dir ${IFCPP_SOURCE_DIR}/examples/SimpleViewerExampleQt)
+SET(RESOURCES ${viewer_dir}/Resources/ifcplusplus.qrc)
+QT5_ADD_RESOURCES(SimpleViewerExample_RESOURCES_RCC ${RESOURCES})
+
 FIND_PACKAGE(OpenSceneGraph REQUIRED osgDB osgUtil osgGA osgFX osgSim osgText osgViewer)
 
 SET(IFCPPVIEWER_SOURCE_FILES 

--- a/examples/SimpleViewerExampleQt/Resources/ifcplusplus.qrc
+++ b/examples/SimpleViewerExampleQt/Resources/ifcplusplus.qrc
@@ -4,9 +4,14 @@
         <file>styles.css</file>
         <file>img/appicon.ico</file>
         <file>img/bulb.png</file>
+        <file>img/Bulb.svg</file>
         <file>img/dropDownArrow.png</file>
+        <file>img/DropDownArrow.svg</file>
         <file>img/zoomBoundings.png</file>
+        <file>img/ZoomBoundings.svg</file>
         <file>img/RemoveSelectedObjects.png</file>
+        <file>img/RemoveSelectedObjects.svg</file>
         <file>img/IfcPlusPlusViewerWindowIcon.png</file>
+        <file>img/IfcPlusPlusViewerWindowIcon.svg</file>
     </qresource>
 </RCC>

--- a/examples/SimpleViewerExampleQt/Resources/img/Bulb.svg
+++ b/examples/SimpleViewerExampleQt/Resources/img/Bulb.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg3007"
+   height="64px"
+   width="64px">
+  <title
+     id="title829">Bulb</title>
+  <defs
+     id="defs3009" />
+  <metadata
+     id="metadata3012">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Bulb</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>vocx</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:description>A yellow light bulb, with highlights and shadows, shinning</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       id="path822"
+       d="m 13,25 c 0,-7 5,-19 19,-19 14,0 19,12 19,19 0,9 -4,8 -7,13 -1.855041,3.091735 -1.019379,7.038759 -2,9 -1,2 -2,2 -2,2 H 25 c 0,0 -1,0 -2,-2 -1.056386,-2.112771 -1.148617,-5.914361 -3,-9 -2.919639,-4.866064 -7,-4 -7,-13 z"
+       style="fill:#e8ee4e;fill-opacity:1;stroke:#363925;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path824"
+       d="m 25,49 h 15 v 8 H 25 Z"
+       style="fill:#c4c4c4;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path824-3"
+       d="m 30,57 h 5 v 3 h -5 z"
+       style="fill:#c4c4c4;fill-opacity:1;stroke:#3c3c3c;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path822-6"
+       d="m 21,33 c 0,0 4,1 11,1 7,0 11,-1 11,-1 0,3 -3,1 -3,5 0,3 0,3 -1,5 -1,2 -3,2 -3,2 h -7 c 0,0 -2,0 -3,-2 -1,-2 -1,-2 -1,-5 0,-4 -4,-2 -4,-5 z"
+       style="fill:#e8c016;fill-opacity:1;stroke:#e8c016;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#e8c016;fill-opacity:1;stroke:#e8c016;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 42,28 c 3,-2 4,-5 4,-7 0,-2 -2,-5 -3,-6 -4.527693,-4.527693 -17,-5 -22,0 -1,1 -3,4 -3,6 0,2 1,5 4,7 0,0 5,1 10,1 5,0 10,-1 10,-1 z"
+       id="path856" />
+    <g
+       transform="translate(-1)"
+       id="g976">
+      <path
+         id="path892"
+         d="M 9,21 H 3"
+         style="fill:none;stroke:#363925;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path892-5"
+         d="M 10,35 4.3431459,37"
+         style="fill:none;stroke:#363925;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path892-5-6"
+         d="m 17,44 -4.472136,4"
+         style="fill:none;stroke:#363925;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path892-2"
+         d="M 12,7 7.527864,3"
+         style="fill:none;stroke:#363925;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="g839"
+       transform="matrix(-1,0,0,1,64.996399,0)">
+      <path
+         style="fill:none;stroke:#363925;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 9,21 H 3"
+         id="path831" />
+      <path
+         style="fill:none;stroke:#363925;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 10,35 4.3431459,37"
+         id="path833" />
+      <path
+         style="fill:none;stroke:#363925;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 17,44 -4.472136,4"
+         id="path835" />
+      <path
+         style="fill:none;stroke:#363925;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 12,7 7.527864,3"
+         id="path837" />
+    </g>
+    <path
+       id="path841"
+       d="m 35,24 c 2.086806,-1.707714 2.782408,-4.269288 2.782408,-5.977003 0,-1.707717 -1.391205,-4.269289 -2.086806,-5.123147 -3.149472,-3.8660043 -11.82523,-4.2692874 -15.30324,0 -0.695601,0.853858 -2.086805,3.41543 -2.086805,5.123147 0,1.707715 0.695602,4.269289 2.782407,5.977003 0,0 3.478009,0.853858 6.956019,0.853858 C 31.521991,24.853858 35,24 35,24 Z"
+       style="fill:#f8f9c7;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/examples/SimpleViewerExampleQt/Resources/img/DropDownArrow.svg
+++ b/examples/SimpleViewerExampleQt/Resources/img/DropDownArrow.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg3007"
+   height="64px"
+   width="64px">
+  <title
+     id="title844">DropDownArrow</title>
+  <defs
+     id="defs3009" />
+  <metadata
+     id="metadata3012">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>DropDownArrow</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>vocx</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:description>A gray arrow pointing downwards</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       style="fill:#949ea8;fill-opacity:1;stroke:#2d2d33;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 8,25.539095 24,21 24,-21 v -2 H 8 Z"
+       id="path825" />
+  </g>
+</svg>

--- a/examples/SimpleViewerExampleQt/Resources/img/IfcPlusPlusViewerWindowIcon.svg
+++ b/examples/SimpleViewerExampleQt/Resources/img/IfcPlusPlusViewerWindowIcon.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg3007"
+   height="64px"
+   width="64px">
+  <title
+     id="title820">IFC++ logo</title>
+  <defs
+     id="defs3009" />
+  <metadata
+     id="metadata3012">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>IFC++ logo</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>vocx</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:description>The letters 'IFC' and two plus signs</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       id="path910"
+       d="m 6,5 h 6 V 30 H 6 Z"
+       style="fill:#4e7492;fill-opacity:1;stroke:#1c1c33;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#4e7492;fill-opacity:1;stroke:#1c1c33;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18,5 h 16 v 5 H 24 v 5 h 10 v 5 H 24 v 10 h -6 z"
+       id="path912" />
+    <path
+       id="path914"
+       d="m 59,6 v 4 c 0,0 -14,-6 -14,7 0,13 14,8 14,8 v 4 C 59,29 39,34 39,17 39,0 59,6 59,6 Z"
+       style="fill:#4e7492;fill-opacity:1;stroke:#1c1c33;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#1ba737;fill-opacity:1;stroke:#142513;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 15,39 h 6 v 7 h 7 v 6 h -7 v 7 H 15 V 52 H 8 v -6 h 7 z"
+       id="path924" />
+    <path
+       id="path818"
+       d="m 43,39 h 6 v 7 h 7 v 6 h -7 v 7 h -6 v -7 h -7 v -6 h 7 z"
+       style="fill:#1ba737;fill-opacity:1;stroke:#142513;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/examples/SimpleViewerExampleQt/Resources/img/RemoveSelectedObjects.svg
+++ b/examples/SimpleViewerExampleQt/Resources/img/RemoveSelectedObjects.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg3007"
+   height="64px"
+   width="64px">
+  <title
+     id="title819">RemoveSelectedObjects</title>
+  <defs
+     id="defs3009" />
+  <metadata
+     id="metadata3012">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>RemoveSelectedObjects</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>vocx</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:description>A red cross on top of gray figures simulating a building, like canceling them</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       id="path823"
+       d="M 8,35 H 56 V 51 H 8 Z"
+       style="fill:#949ea8;fill-opacity:1;stroke:#2d2d33;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#949ea8;fill-opacity:1;stroke:#2d2d33;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 8,29 32,8 56,29 v 2 H 8 Z"
+       id="path825" />
+    <path
+       id="path827"
+       d="M 9,5 5,9 27.958984,31.5 5,54 9,58 32,35.460938 55,58 59,54 36.041016,31.5 59,9 55,5 32,27.539062 Z"
+       style="fill:#cc3216;fill-opacity:1;stroke:#3c1b1b;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/examples/SimpleViewerExampleQt/Resources/img/ZoomBoundings.svg
+++ b/examples/SimpleViewerExampleQt/Resources/img/ZoomBoundings.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg3007"
+   height="64px"
+   width="64px">
+  <title
+     id="title822">ZoomBoundings</title>
+  <defs
+     id="defs3009" />
+  <metadata
+     id="metadata3012">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>ZoomBoundings</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>vocx</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:description>Four blue arrows extending from the center outwards to each of the four corners</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       id="g825">
+      <path
+         style="fill:#4172bf;fill-opacity:1;stroke:#1c2238;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 43.041016,24.960938 55,13 58,17 V 6 H 47 l 4,3 -12,12 z"
+         id="path827" />
+      <path
+         id="path821"
+         d="M 21.959026,24.960938 10.000042,13 l -3,4 V 6 h 11 l -4,3 12,12 z"
+         style="fill:#4172bf;fill-opacity:1;stroke:#1c2238;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       transform="matrix(1,0,0,-1,0,62.960897)"
+       id="g832">
+      <path
+         id="path828"
+         d="M 43.041016,24.960938 55,13 58,17 V 6 H 47 l 4,3 -12,12 z"
+         style="fill:#4172bf;fill-opacity:1;stroke:#1c2238;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:#4172bf;fill-opacity:1;stroke:#1c2238;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 21.959026,24.960938 10.000042,13 l -3,4 V 6 h 11 l -4,3 12,12 z"
+         id="path830" />
+    </g>
+  </g>
+</svg>

--- a/examples/SimpleViewerExampleQt/Resources/styles.css
+++ b/examples/SimpleViewerExampleQt/Resources/styles.css
@@ -21,14 +21,14 @@ QGroupBox {
 }
 
 QGroupBox::title {
-	 subcontrol-origin: margin;
-	 subcontrol-position: top left;
-	 padding: 0 3px;
-	 left: 7px;
-	 top: -2px;
-	 color: #82878b;
- }
- 
+	subcontrol-origin: margin;
+	subcontrol-position: top left;
+	padding: 0 3px;
+	left: 7px;
+	top: -2px;
+	color: #82878b;
+}
+
 /* QLineEdit **************************************/
 QLineEdit { background-color: #fdfdfd; border: 1px solid #b0b0b0; height: 16px; margin: 1 1 1 1; }
 QLineEdit::disabled { color:#969696; background-color: #eaeaea; border: 1px solid #b0b0b0; }
@@ -82,8 +82,8 @@ QTabBar::tab
 
 QTabBar::tab:hover { background: #ececec; }
 QTabBar::tab:selected { background: #f5f5f5; border-color: #9B9B9B; border-bottom: 0px; }
-QTabBar::tab:first:selected { margin-left: 0;  }
-QTabBar::tab:last:selected { margin-right: 0;  }
+QTabBar::tab:first:selected { margin-left: 0; }
+QTabBar::tab:last:selected { margin-right: 0; }
 QTabBar::tab:only-one {  margin: 0; }
 
 
@@ -110,7 +110,7 @@ QHeaderView
 	background-color: #cccccc;
 	border: 0px;
 }
- 
+
 QHeaderView::section 
 {
 	background-color: #dcdcdc;
@@ -127,31 +127,31 @@ QGraphicsView { background-color: #eef0f2; }
 
 /* QComboBox **************************************/
 QComboBox {
-	 border: 1px solid #cccccc;
-	 padding: 1px 18px 1px 3px;
-	 min-width: 6em;
-	 background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-								  stop: 0 #E1E1E1, stop: 0.4 #DDDDDD,
-								  stop: 0.5 #D8D8D8, stop: 1.0 #D3D3D3);
- }
- 
+    border: 1px solid #cccccc;
+    padding: 1px 18px 1px 3px;
+    min-width: 6em;
+    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+                                stop: 0 #E1E1E1, stop: 0.4 #DDDDDD,
+                                stop: 0.5 #D8D8D8, stop: 1.0 #D3D3D3);
+}
+
 QComboBox:!editable, QComboBox::drop-down:editable {
-	  background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-								  stop: 0 #E1E1E1, stop: 0.4 #DDDDDD,
-								  stop: 0.5 #D8D8D8, stop: 1.0 #D3D3D3);
+    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+                                stop: 0 #E1E1E1, stop: 0.4 #DDDDDD,
+                                stop: 0.5 #D8D8D8, stop: 1.0 #D3D3D3);
 }
 
 
 QComboBox:!editable:on, QComboBox::drop-down:editable:on {
-	 background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-								 stop: 0 #D3D3D3, stop: 0.4 #D8D8D8,
-								 stop: 0.5 #DDDDDD, stop: 1.0 #E1E1E1);
- }
+    background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
+                                stop: 0 #D3D3D3, stop: 0.4 #D8D8D8,
+                                stop: 0.5 #DDDDDD, stop: 1.0 #E1E1E1);
+}
 
 QComboBox:on {
-	 padding-top: 3px;
-	 padding-left: 4px;
- }
+	padding-top: 3px;
+	padding-left: 4px;
+}
 
 QComboBox::drop-down {
 	subcontrol-origin: padding;
@@ -163,12 +163,13 @@ QComboBox::drop-down {
 	background-color:#efefef;
 }
 
- QComboBox::down-arrow {
-	 image: url(:img/DropDownArrow.svg);
+QComboBox::down-arrow {
+	image: url(:img/DropDownArrow.svg);
 	width: 16px;
- }
+}
 
- QComboBox::down-arrow:on {
-	 top: 1px;
-	 left: 1px;
- }
+QComboBox::down-arrow:on {
+	top: 1px;
+	left: 1px;
+}
+

--- a/examples/SimpleViewerExampleQt/Resources/styles.css
+++ b/examples/SimpleViewerExampleQt/Resources/styles.css
@@ -164,7 +164,8 @@ QComboBox::drop-down {
 }
 
  QComboBox::down-arrow {
-	 image: url(:img/dropDownArrow.png);
+	 image: url(:img/DropDownArrow.svg);
+	width: 16px;
  }
 
  QComboBox::down-arrow:on {

--- a/examples/SimpleViewerExampleQt/src/gui/MainWindow.cpp
+++ b/examples/SimpleViewerExampleQt/src/gui/MainWindow.cpp
@@ -37,7 +37,7 @@ MainWindow::MainWindow( IfcPlusPlusSystem* sys, ViewerWidget* vw, QWidget *paren
 {
 	m_system = sys;
 	setWindowTitle("IfcQuery example application");
-	setWindowIcon( QIcon( ":img/IfcPlusPlusViewerWindowIcon.png" ) );
+	setWindowIcon(QIcon(":img/IfcPlusPlusViewerWindowIcon.svg"));
 	
 	// global style sheet definitions
 	QFile file( ":styles.css" );
@@ -46,12 +46,12 @@ MainWindow::MainWindow( IfcPlusPlusSystem* sys, ViewerWidget* vw, QWidget *paren
 	setStyleSheet( styleSheet );
 	createTabWidget();
 
-	QAction* zoom_bounds_btn = new QAction(QIcon(":img/zoomBoundings.png"), "&Zoom to boundings", this );
+	QAction* zoom_bounds_btn = new QAction(QIcon(":img/ZoomBoundings.svg"), "&Zoom to boundings", this );
 	zoom_bounds_btn->setShortcut(tr("Ctrl+Z"));
 	zoom_bounds_btn->setStatusTip("Zoom to boundings");
 	connect(zoom_bounds_btn, &QAction::triggered, this, &MainWindow::slotBtnZoomBoundingsClicked);
 
-	QAction* remove_selected_objects = new QAction(QIcon(":img/RemoveSelectedObjects.png"), "&Remove selected objects [del]", this );
+	QAction* remove_selected_objects = new QAction(QIcon(":img/RemoveSelectedObjects.svg"), "&Remove selected objects [del]", this );
 	remove_selected_objects->setStatusTip("Remove selected objects [del]");
 	connect(remove_selected_objects, &QAction::triggered, this, &MainWindow::slotBtnRemoveSelectedObjectsClicked);
 

--- a/examples/SimpleViewerExampleQt/src/gui/TabView.cpp
+++ b/examples/SimpleViewerExampleQt/src/gui/TabView.cpp
@@ -72,11 +72,11 @@ TabView::TabView( IfcPlusPlusSystem* sys, ViewerWidget* vw ) : m_system(sys), m_
 
 	// light button
 	QToolButton* btn_toggle_light = new QToolButton();
-	btn_toggle_light->setIcon( QIcon( ":img/bulb.png" ) );
-	btn_toggle_light->setIconSize( QSize( 22, 22 ) );
-	btn_toggle_light->setToolTip( "Light on/off" );
-	btn_toggle_light->setCheckable( true );
-	btn_toggle_light->setChecked( true );
+	btn_toggle_light->setIcon(QIcon(":img/Bulb.svg"));
+	btn_toggle_light->setIconSize(QSize(22, 22));
+	btn_toggle_light->setToolTip("Light on/off");
+	btn_toggle_light->setCheckable(true);
+	btn_toggle_light->setChecked(true);
 	connect( btn_toggle_light,	SIGNAL( clicked() ),	this,	SLOT( slotToggleSceneLight() ) );
 
 	// number of vertices per cycle


### PR DESCRIPTION
* Add the `ifcplusplus.qrc` file to the Qt 5 resources, so that the icons are compiled and displayed correctly in Linux. This was taken from @berndhahnebach's branch, https://github.com/berndhahnebach/ifcplusplus/.
* Add new SVG icons to replace the older PNG icons; the SVG icons have the advantage that they can be scaled to an arbitrary size and will keep their details, so they look better in icons, buttons, and toolbars. The older icons are PNGs of a very small size, like 16x16 px, so they don't look good when they are stretched out just a bit. The new icons have a native size of 64x64 px, so they look good when shrunk to 16 px or 24 px or any size.
* Update the corresponding code in `MainWindow.cpp`, `TabView.cpp`, and `styles.css` to use the new icons.
* Update `styles.css` to avoid mixing tabs and spaces in the same line. I replaced the tabs with 4 spaces to make sure the code aligns correctly, which I suspect was the original intention.
* More information on compiling IFC++ for Linux in the FreeCAD wiki, https://wiki.freecadweb.org/IfcPlusPlus

This is how the new icons look in the interface in Ubuntu Linux:
![Screenshot_new_icons](https://user-images.githubusercontent.com/53131517/91000528-f8c50680-e58e-11ea-9c01-1384b736b1ab.png)
