### PR TITLE
Fix of parsing lists of strings where strings contain commas or closing parentheses

### DIFF
--- a/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.h
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.h
@@ -431,6 +431,9 @@ void readTypeOfStringList( const wchar_t* str, std::vector<shared_ptr<T> >& targ
 			continue;
 		}
 
+		if ( *ch == '\'' )
+			findEndOfWString( ch );
+
 		while( *ch != ',' && *ch != L'\0' && *ch != ')' )
 		{
 			++ch;


### PR DESCRIPTION
Previous version of code treats comma inside a string as a list item delimiter, and closing parenthesis as the end of the list.

But the function `readTypeOfStringList` looks in general strange. It attempts to trim trailing white-spaces without updating `last_token` variable. In the case of existence trailing white-spaces at beginning or end of list item it would fail to remove apostrophes. These bugs don't happen due to `splitIntoStepLines` function which removes all separators. Thus, it should be decided, whether `readTypeOfStringList` should correctly process possible white-spaces from its input, or it should assume that all separators are already removed (some assertions are needed in this case probably).
Moreover, it doesn't make assumption that any STEP string in enclosed in apostrophes. Is there really any CAD-system which exports such IFC-files, or it's been made just in case? Probably, it makes sense to rewrite the function using regular expressions, but in case of such refactoring, it may be simpler to assume that all strings are bounded with apostrophes.