### PR TITLE
Fix of parsing string lists with unpaired parentheses inside any string

### DIFF
--- a/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
@@ -314,8 +314,8 @@ void ReaderSTEP::readHeader( const std::string& read_in, shared_ptr<BuildingMode
 	
 	std::vector<std::wstring> vec_header_lines;
 	// split into lines
-	wchar_t* stream_pos = &file_header_wstr[0];
-	wchar_t* last_token = stream_pos;
+	const wchar_t* stream_pos = &file_header_wstr[0];
+	const wchar_t* last_token = stream_pos;
 
 	if( stream_pos == nullptr )
 	{
@@ -332,7 +332,7 @@ void ReaderSTEP::readHeader( const std::string& read_in, shared_ptr<BuildingMode
 
 		if( *stream_pos == ';' )
 		{
-			wchar_t* begin_line = last_token;
+			const wchar_t* begin_line = last_token;
 			std::wstring single_step_line( begin_line, stream_pos-last_token );
 			vec_header_lines.push_back( single_step_line );
 
@@ -420,7 +420,7 @@ void ReaderSTEP::splitIntoStepLines(const std::string& read_in, std::vector<std:
 
 	// find beginning of data lines
 	const size_t length = read_in.length();
-	char* stream_pos = const_cast<char*>(&read_in[0]);
+	const char* stream_pos = &read_in[0];
 	if( stream_pos == nullptr )
 	{
 		throw BuildingException("Invalid file content", __FUNC__);
@@ -448,7 +448,7 @@ void ReaderSTEP::splitIntoStepLines(const std::string& read_in, std::vector<std:
 	}
 
 	// split into data lines: #1234=IFCOBJECTNAME(...,...,(...,...),...);
-	char* progress_anchor = stream_pos;
+	const char* progress_anchor = stream_pos;
 	std::string single_step_line;
 
 	while( *stream_pos != '\0' )
@@ -462,7 +462,7 @@ void ReaderSTEP::splitIntoStepLines(const std::string& read_in, std::vector<std:
 
 		if( *( stream_pos )  == '!' )
 		{
-			char* stream_pos_next = stream_pos;
+			const char* stream_pos_next = stream_pos;
 			++stream_pos_next;
 			if( *stream_pos_next != '\0' )
 			{
@@ -490,7 +490,7 @@ void ReaderSTEP::splitIntoStepLines(const std::string& read_in, std::vector<std:
 
 		if( *stream_pos == '\'' )
 		{
-			char* string_start = stream_pos;
+			const char* string_start = stream_pos;
 			findEndOfString(stream_pos);
 			std::string s(string_start, stream_pos - string_start);
 			single_step_line += s;

--- a/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.cpp
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.cpp
@@ -81,6 +81,11 @@ void checkOpeningClosingParenthesis( const wchar_t* ch_check )
 		{
 			++num_closing;
 		}
+		else if ( *ch_check == '\'' )
+		{
+			findEndOfWString( ch_check );
+			continue;
+		}
 		++ch_check;
 	}
 	if( num_opening != num_closing )

--- a/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.cpp
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.cpp
@@ -532,10 +532,10 @@ void readStringList( const std::wstring& str, std::vector<std::wstring>& vec )
 	}
 }
 
-void findEndOfString( char*& stream_pos )
+void findEndOfString( const char*& stream_pos )
 {
 	++stream_pos;
-	char* pos_begin = stream_pos;
+	const char* pos_begin = stream_pos;
 
 	// beginning of string, continue to end
 	while( *stream_pos != '\0' )
@@ -592,10 +592,10 @@ void findEndOfString( char*& stream_pos )
 	}
 }
 
-void findEndOfWString( wchar_t*& stream_pos )
+void findEndOfWString( const wchar_t*& stream_pos )
 {
 	++stream_pos;
-	wchar_t* pos_begin = stream_pos;
+	const wchar_t* pos_begin = stream_pos;
 
 	// beginning of string, continue to end
 	while( *stream_pos != '\0' )
@@ -789,7 +789,7 @@ void decodeArgumentStrings( std::vector<std::string>& entity_arguments, std::vec
 // caution: when using OpenMP, this method runs in parallel threads
 void tokenizeEntityArguments( const std::string& argument_str, std::vector<std::string>& entity_arguments )
 {
-	char* stream_pos = const_cast<char*>(argument_str.c_str());
+	const char* stream_pos = argument_str.c_str();
 	if( *stream_pos != '(' )
 	{
 		return;
@@ -797,7 +797,7 @@ void tokenizeEntityArguments( const std::string& argument_str, std::vector<std::
 
 	++stream_pos;
 	int num_open_braces = 1;
-	char* last_token = stream_pos;
+	const char* last_token = stream_pos;
 
 	while( *stream_pos != '\0' )
 	{
@@ -820,14 +820,14 @@ void tokenizeEntityArguments( const std::string& argument_str, std::vector<std::
 					++last_token;
 				}
 
-				char* begin_arg = last_token;
+				const char* begin_arg = last_token;
 
 				// skip whitespace
 				while( isspace( *begin_arg ) ) 
 				{
 					++begin_arg; 
 				}
-				char* end_arg = stream_pos-1;
+				const char* end_arg = stream_pos-1;
 				entity_arguments.emplace_back( begin_arg, end_arg-begin_arg+1 );
 				last_token = stream_pos;
 			}
@@ -842,7 +842,7 @@ void tokenizeEntityArguments( const std::string& argument_str, std::vector<std::
 					++last_token;
 				}
 
-				char* begin_arg = last_token;
+				const char* begin_arg = last_token;
 
 				// skip whitespace
 				while( isspace( *begin_arg ) ) 
@@ -853,7 +853,7 @@ void tokenizeEntityArguments( const std::string& argument_str, std::vector<std::
 				int remaining_size = static_cast<int>(stream_pos - begin_arg);
 				if( remaining_size > 0 )
 				{
-					char* end_arg = stream_pos-1;
+					const char* end_arg = stream_pos-1;
 					entity_arguments.emplace_back( begin_arg, end_arg-begin_arg+1 );
 				}
 				break;
@@ -867,7 +867,7 @@ void tokenizeEntityArguments( const std::string& argument_str, std::vector<std::
 // caution: when using OpenMP, this method runs in parallel threads
 void tokenizeEntityArguments( const std::wstring& argument_str, std::vector<std::wstring>& entity_arguments )
 {
-	wchar_t* stream_pos = const_cast<wchar_t*>(argument_str.c_str());
+	const wchar_t* stream_pos = argument_str.c_str();
 	if( *stream_pos != '(' )
 	{
 		return;
@@ -875,7 +875,7 @@ void tokenizeEntityArguments( const std::wstring& argument_str, std::vector<std:
 
 	++stream_pos;
 	int num_open_braces = 1;
-	wchar_t* last_token = stream_pos;
+	const wchar_t* last_token = stream_pos;
 
 	while( *stream_pos != '\0' )
 	{
@@ -898,14 +898,14 @@ void tokenizeEntityArguments( const std::wstring& argument_str, std::vector<std:
 					++last_token;
 				}
 
-				wchar_t* begin_arg = last_token;
+				const wchar_t* begin_arg = last_token;
 
 				// skip whitespace
 				while( isspace( *begin_arg ) ) 
 				{
 					++begin_arg; 
 				}
-				wchar_t* end_arg = stream_pos-1;
+				const wchar_t* end_arg = stream_pos-1;
 				entity_arguments.emplace_back( begin_arg, end_arg-begin_arg+1 );
 				last_token = stream_pos;
 			}
@@ -920,7 +920,7 @@ void tokenizeEntityArguments( const std::wstring& argument_str, std::vector<std:
 					++last_token;
 				}
 
-				wchar_t* begin_arg = last_token;
+				const wchar_t* begin_arg = last_token;
 
 				// skip whitespace
 				while( isspace( *begin_arg ) ) 
@@ -931,7 +931,7 @@ void tokenizeEntityArguments( const std::wstring& argument_str, std::vector<std:
 				int remaining_size = static_cast<int>(stream_pos - begin_arg);
 				if( remaining_size > 0 )
 				{
-					wchar_t* end_arg = stream_pos-1;
+					const wchar_t* end_arg = stream_pos-1;
 					entity_arguments.emplace_back( begin_arg, end_arg-begin_arg+1 );
 				}
 				break;

--- a/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.h
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.h
@@ -56,8 +56,8 @@ void tokenizeInlineArgument(std::wstring arg, std::wstring& keyword, std::wstrin
 void tokenizeList( std::wstring& list_str, std::vector<std::wstring>& list_items );
 void tokenizeEntityList( std::wstring& list_str, std::vector<int>& list_items );
 void findLeadingTrailingParanthesis(wchar_t* ch, wchar_t*& pos_opening, wchar_t*& pos_closing);
-void findEndOfString(char*& stream_pos);
-void findEndOfWString(wchar_t*& stream_pos);
+void findEndOfString(const char*& stream_pos);
+void findEndOfWString(const wchar_t*& stream_pos);
 void checkOpeningClosingParenthesis(const wchar_t* ch_check);
 
 IFCQUERY_EXPORT bool std_iequal(const std::wstring& a, const std::wstring& b);
@@ -405,8 +405,8 @@ template<typename T>
 void readTypeOfStringList( const wchar_t* str, std::vector<shared_ptr<T> >& target_vec )
 {
 	// example: ('Tahoma')
-	wchar_t* ch = (wchar_t*)str;
-	wchar_t* last_token = nullptr;
+	const wchar_t* ch = str;
+	const wchar_t* last_token = nullptr;
 
 	// ignore leading space or opening parenthesis
 	while( *ch != '\0' )


### PR DESCRIPTION
* Maintenance: constness added somewhere in order to use `findEndOfWString` with pointer to constant string; some const_casts deleted.
* Bugfix.