### PR TITLE
Fix race conditions in ReaderSTEP.cpp

### DIFF
--- a/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
@@ -583,8 +583,10 @@ void ReaderSTEP::readStepLines( const std::vector<std::string>& step_lines, std:
 #ifdef ENABLE_OPENMP
 #pragma omp critical
 #endif
-							unkown_entities.insert( unknown_keyword );
-							err_unknown_entity << "unknown IFC entity: " << unknown_keyword << std::endl;
+							{
+								unkown_entities.insert( unknown_keyword );
+								err_unknown_entity << "unknown IFC entity: " << unknown_keyword << std::endl;
+							}
 						}
 					}
 				}
@@ -595,8 +597,10 @@ void ReaderSTEP::readStepLines( const std::vector<std::string>& step_lines, std:
 #ifdef ENABLE_OPENMP
 #pragma omp critical
 #endif
-						unkown_entities.insert( unknown_keyword );
-						err_unknown_entity << "unknown IFC entity: " << unknown_keyword << std::endl;
+						{
+							unkown_entities.insert( unknown_keyword );
+							err_unknown_entity << "unknown IFC entity: " << unknown_keyword << std::endl;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Considering you have a really bad file, the amount of threads accessing "err_unknown_entity" can cause applications to quit without error.

This error only happens if OpenMP is enabled. 
(Error happend for me on MSVC++2015 Express)