### PR TITLE
Fix typo un CMakeLists.txt

### DIFF
--- a/examples/SimpleViewerExampleQt/CMakeLists.txt
+++ b/examples/SimpleViewerExampleQt/CMakeLists.txt
@@ -60,7 +60,7 @@ SET(IFCPPVIEWER_MOC_FILES
     src/gui/MainWindow.h
     src/gui/TabReadWrite.h
     src/gui/TabView.h
-	src/gui/storeyShiftWidget.h
+    src/gui/StoreyShiftWidget.h
     src/viewer/ViewerWidget.h
 )
 


### PR DESCRIPTION
CMake doesn't find the misspelled file in Ubuntu.