### PR TITLE
Added encoding of tab symbol to encodeStepString() method.

### DIFF
--- a/IfcPlusPlus/src/ifcpp/writer/WriterUtil.cpp
+++ b/IfcPlusPlus/src/ifcpp/writer/WriterUtil.cpp
@@ -192,7 +192,13 @@ std::string encodeStepString( const std::wstring& str )
 	while( *stream_pos != '\0' )
 	{
 		wchar_t append_char = *stream_pos;
-		if( append_char == 10 )
+		if( append_char == 9 )
+		{
+			closeUnicodeBlockIfOpened();
+			// encode tab
+			result_str.append("\\X\\09");
+		}
+		else if( append_char == 10 )
 		{
 			closeUnicodeBlockIfOpened();
 			// encode new line


### PR DESCRIPTION
Tab symbol was not encoded in encodeStepString() method which led to illegal character error while IFC schema check.
This pull request adds encoding of tab symbol.