### PR TITLE
ReaderSTEP::readHeader has been fixed for unknown schema case.

### DIFF
--- a/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
@@ -414,9 +414,13 @@ void ReaderSTEP::readHeader( const std::string& read_in, shared_ptr<BuildingMode
 			{
 				target_model->m_ifc_schema_version_loaded_file = BuildingModel::IFC4X1;
 			}
-			else
+			else if( !file_schema_args.empty() )
 			{
 				target_model->m_ifc_schema_version_loaded_file = BuildingModel::IFC_VERSION_UNKNOWN;
+			}
+			else
+			{
+				target_model->m_ifc_schema_version_loaded_file = BuildingModel::IFC_VERSION_UNDEFINED;
 			}
 		}
 	}

--- a/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
@@ -416,7 +416,7 @@ void ReaderSTEP::readHeader( const std::string& read_in, shared_ptr<BuildingMode
 			}
 			else
 			{
-				target_model->m_ifc_schema_version_loaded_file = BuildingModel::IFC_VERSION_UNDEFINED;
+				target_model->m_ifc_schema_version_loaded_file = BuildingModel::IFC_VERSION_UNKNOWN;
 			}
 		}
 	}


### PR DESCRIPTION
The value of the "m_ifc_file_schema_enum" field has been corrected in the case of an unknown schema version. IFC_VERSION_UNKNOWN was not used at all.