### PR TITLE
Fix misc. trivial typos

### DIFF
--- a/IfcPlusPlus/CMakeLists.txt
+++ b/IfcPlusPlus/CMakeLists.txt
@@ -19,7 +19,7 @@ endif(WIN32)
 file (GLOB ifc4_source "src/ifcpp/IFC4/lib/*.cpp")
 
 if(UNIX)
-    # do not add src/external/XUnzip.cpp on unix plattforms
+    # do not add src/external/XUnzip.cpp on unix platforms
     set(IFCPP_SOURCE_FILES 
         src/ifcpp/IFC4/EntityFactory.cpp
         src/ifcpp/IFC4/TypeFactory.cpp

--- a/IfcPlusPlus/src/ifcpp/geometry/Carve/GeometryInputData.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/Carve/GeometryInputData.h
@@ -680,7 +680,7 @@ public:
 		
 					if (transform_self->m_placement_entity_id >= 0 && transform_self->m_placement_entity_id == transform_other->m_placement_entity_id)
 					{
-						// skip matrices that are the same at both products, to avoid unecessary multiplications and numerical inaccuracies
+						// skip matrices that are the same at both products, to avoid unnecessary multiplications and numerical inaccuracies
 						++it_self;
 						++it_other;
 						continue;

--- a/IfcPlusPlus/src/ifcpp/geometry/Carve/SolidModelConverter.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/Carve/SolidModelConverter.h
@@ -1157,7 +1157,7 @@ public:
 			}
 			polyhedron_data->addVertex( primitive_placement_matrix*carve::geom::VECTOR( 0.0, 0.0, -radius ) ); // bottom
 
-			// uppper triangle fan
+			// upper triangle fan
 			for( int i = 0; i < nvc - 1; ++i )
 			{
 				polyhedron_data->addFace( 0, i + 2, i + 1 );

--- a/IfcPlusPlus/src/ifcpp/geometry/Carve/SplineConverter.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/Carve/SplineConverter.h
@@ -247,7 +247,7 @@ public:
 		const size_t num_curve_pts = num_control_pts * m_geom_settings->getNumVerticesPerControlPoint();
 		std::vector<double> knot_vec;
 
-		//	set weighting factors to 1.0 in case of homogenious curve
+		//	set weighting factors to 1.0 in case of homogeneous curve
 		vec_weights.resize( num_control_pts + 1, 1.0 );
 
 		shared_ptr<IfcBSplineCurveWithKnots> bspline_curve_with_knots = dynamic_pointer_cast<IfcBSplineCurveWithKnots>( bspline_curve );

--- a/IfcPlusPlus/src/ifcpp/geometry/OCC/SplineConverterOCC.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/OCC/SplineConverterOCC.h
@@ -240,7 +240,7 @@ public:
 		const size_t num_curve_pts = num_control_pts * m_geom_settings->getNumVerticesPerControlPoint();
 		std::vector<double> knot_vec;
 
-		//	set weighting factors to 1.0 in case of homogenious curve
+		//	set weighting factors to 1.0 in case of homogeneous curve
 		vec_weights.resize( num_control_pts + 1, 1.0 );
 
 		shared_ptr<IfcBSplineCurveWithKnots> bspline_curve_with_knots = dynamic_pointer_cast<IfcBSplineCurveWithKnots>( bspline_curve );

--- a/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.h
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.h
@@ -427,7 +427,7 @@ void readTypeOfStringList( const wchar_t* str, std::vector<shared_ptr<T> >& targ
 	{
 		if( isspace( *ch ) )
 		{
-			// ingore leading space characters
+			// ignore leading space characters
 			++ch;
 			continue;
 		}


### PR DESCRIPTION
Found via `codespell -q 3 -S ./external,./IfcPlusPlus/src/external -L numer,wallthickness`

Please consider fixing the source typos for `segement`, `segements`, `appearence`, and `tesselator`