### PR TITLE
Fix reading files with apostrophe in the header section.

### DIFF
--- a/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.cpp
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.cpp
@@ -68,6 +68,14 @@ static wchar_t Hex4Wchar(unsigned char h1, unsigned char h2, unsigned char h3, u
 	return (returnValue);
 }
 
+static void addCharWithEscaping( std::wstring& str, wchar_t ch )
+{
+	if ( ch == '\'' || ch == '\\' )
+		str += ch;
+	str += ch;
+}
+
+
 std::string wstring2string(const std::wstring& wstr)
 {
 	std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> StringConverter;
@@ -747,8 +755,7 @@ void decodeArgumentStrings( std::vector<std::string>& entity_arguments, std::vec
 						wchar_t wc = Hex2Wchar(*(stream_pos+3), *(stream_pos+4));
 
 						//unsigned char char_ascii = wctob(wc);
-						arg_str_new += wc;
-
+						addCharWithEscaping(arg_str_new, wc);
 						stream_pos += 5;
 						continue;
 					}
@@ -774,7 +781,7 @@ void decodeArgumentStrings( std::vector<std::string>& entity_arguments, std::vec
 							{
 								wchar_t wc = Hex4Wchar(*(stream_pos), *(stream_pos+1), *(stream_pos+2), *(stream_pos+3));
 								//unsigned char char_ascii = wctob(wc);
-								arg_str_new += wc;
+								addCharWithEscaping(arg_str_new, wc);
 								stream_pos += 4;
 
 							} while (( *stream_pos != '\0' ) && ( *stream_pos != '\\' ));

--- a/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.h
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.h
@@ -120,6 +120,13 @@ inline void readReal( const std::wstring& attribute_value, double& target )
 	target = std::stod( attribute_value );
 }
 
+inline void removeCharEscaping( std::wstring& str, wchar_t ch )
+{
+	const wchar_t escapedCharStr[] = { ch, ch };
+	for ( size_t pos=0; str.npos!=(pos=str.find(escapedCharStr, pos, 2)); ++pos )
+		str.replace(pos, 2, 1, ch);
+}
+
 inline void readString( const std::wstring& attribute_value, std::wstring& target )
 {
 	if( attribute_value.size() < 2 )
@@ -129,7 +136,9 @@ inline void readString( const std::wstring& attribute_value, std::wstring& targe
 	}
 	if( attribute_value[0] == '\'' && attribute_value[attribute_value.size()-1] == '\'' )
 	{
-		target = attribute_value.substr( 1, attribute_value.size()-2 );
+		target = attribute_value.substr( 1, attribute_value.size()-2);
+		removeCharEscaping(target, '\'');
+		removeCharEscaping(target, '\\');
 	}
 }
 


### PR DESCRIPTION
Fix two problems.
1. Header reader failes on user name with apostrophe:
`FILE_NAME('1.ifc','2022-01-28T15:23:18',('admin\X\27'),(''),'IfcPlusPlus','','');`

2. Duplicating `\` or `'` when read string atributes of entites:
`#53= IFCCOLUMN('2Vl8RxOHj99fWB7IRf2gY0',$,'Column1',$,$,#58,#81,'\\',$);`

ISO 10303-21 standard states that:
`A string shall be encoded as an apostrophe "'", followed by zero or more characters from the basic alphabet, and ended by an apostrophe "'". The null string (string of length zero) shall be encoded by two consecutive apostrophes "''". Within a string, a single apostrophe shall be encoded as two consecutive apostrophes. Within a string, a single reverse solidus "\" shall be encoded as two reverse solidi "\\".`