### PR TITLE
Removed use of non-standard ssize_t from Carve RTree implementation.

### DIFF
--- a/external/Carve/src/include/carve/rtree.hpp
+++ b/external/Carve/src/include/carve/rtree.hpp
@@ -430,10 +430,10 @@ struct RTreeNode {
     }
 
     for (size_t j = 0; j < best.partition_pos; ++j) {
-      part_num[begin[(ssize_t)j]] = part_curr;
+      part_num[begin[j]] = part_curr;
     }
     for (size_t j = best.partition_pos; j < N; ++j) {
-      part_num[begin[(ssize_t)j]] = part_next;
+      part_num[begin[j]] = part_next;
     }
     ++part_next;
 


### PR DESCRIPTION
When compiling in Visual Studio 2022, I get a compiler error in
rtree.hpp. The issue was that the `ssize_t` type could not be
found. This is a non-standard type defined in a Windows SDK header
(basetsd.h). Since the cast didn't seem to be doing anything anyway,
I simply removed it--why cast a size_t to a signed type?

This type is also used in polyline_iter.hpp. That file includes
the header in which it's defined. If we don't want to remove the
cast we could do that here as well (at the cost of portability).