### PR TITLE
Added a check that argument strings don't contain symbols outside the…

### DIFF
--- a/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.cpp
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderUtil.cpp
@@ -687,6 +687,8 @@ void decodeArgumentStrings( std::vector<std::string>& entity_arguments, std::vec
 		char* stream_pos = const_cast<char*>(argument_str.c_str());		// ascii characters from STEP file
 		while( *stream_pos != '\0' )
 		{
+			if (!std::isspace(static_cast<unsigned char>(*stream_pos)) && ((*stream_pos) < 32 || (*stream_pos) > 126))
+				throw BuildingException("unsupported character encountered", __FUNC__);
 			if( *stream_pos == '\\' )
 			{
 				if( *(stream_pos+1) == 'S' )


### PR DESCRIPTION
… character code range supported by encoding

Hi, we encountered invalid IFC projects containing unencoded cyrillic strings and IFCPlusPlus decoding routine didn't complain about it and produced broken strings that could lead to crashes while being interpreted as UTF-8 in our application.
We addresed the issue by adding the provided check.