### PR TITLE
Add missing include for uint32_t.

### DIFF
--- a/IfcPlusPlus/src/external/Carve/src/include/carve/rtree.hpp
+++ b/IfcPlusPlus/src/external/Carve/src/include/carve/rtree.hpp
@@ -32,6 +32,7 @@
 #include <iostream>
 
 #include <cmath>
+#include <cstdint>
 #include <limits>
 
 namespace carve {


### PR DESCRIPTION
This patch was added to the Debian package of ifcplusplus