### PR TITLE
disable using execution policy while reading STEP file on MacOS compile

### DIFF
--- a/IfcPlusPlus/src/ifcpp/geometry/GeometryConverter.h
+++ b/IfcPlusPlus/src/ifcpp/geometry/GeometryConverter.h
@@ -948,7 +948,9 @@ public:
 
 		std::mutex writelock_map, writelock_ifc_project, writelock_progress, writelock_err;
 		int i = 0;
-#if defined(_DEBUG) //|| defined(_DEBUG_RELEASE) //|| defined(__GNUC__)  // disable threading for Linux due to unknown issues with std::thread
+#if defined(__APPLE__) || defined(__OSX__)
+	std::for_each(
+#elif defined(_DEBUG) //|| defined(_DEBUG_RELEASE) //|| defined(__GNUC__)  // disable threading for Linux due to unknown issues with std::thread
 		std::for_each(std::execution::seq,
 #else
 		std::for_each(std::execution::par,
@@ -1047,7 +1049,9 @@ public:
 			});
 
 		// subtract openings in assemblies etc, in case the opening is attached at the top level
-#if defined(_DEBUG) || defined(_DEBUG_RELEASE) //|| defined(__GNUC__)  // disable threading for Linux due to unknown issues with std::thread
+#if defined(__APPLE__) || defined(__OSX__)
+	std::for_each(
+#elif defined(_DEBUG) || defined(_DEBUG_RELEASE) //|| defined(__GNUC__)  // disable threading for Linux due to unknown issues with std::thread
 		std::for_each(std::execution::seq,
 #else
 		std::for_each(std::execution::par,

--- a/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
+++ b/IfcPlusPlus/src/ifcpp/reader/ReaderSTEP.cpp
@@ -566,7 +566,9 @@ void ReaderSTEP::readEntityArguments(std::vector<std::pair<std::string, shared_p
 	std::unordered_set<std::string> setClassesWithAdjustedArguments;
 #endif
 
-#ifdef _DEBUG_READ_SEQENTIAL
+#if defined(__APPLE__) || defined(__OSX__)
+	std::for_each(
+#elif defied(_DEBUG_READ_SEQENTIAL)
 	std::for_each(std::execution::seq,
 #else
 	std::for_each(std::execution::par,

--- a/IfcPlusPlus/src/ifcpp/writer/WriterSTEP.cpp
+++ b/IfcPlusPlus/src/ifcpp/writer/WriterSTEP.cpp
@@ -72,7 +72,13 @@ void WriterSTEP::writeModelToStream(std::stringstream& stream, shared_ptr<Buildi
 	auto t_start = std::chrono::high_resolution_clock::now();
 	std::atomic<int> counter = 0;
 	size_t numEntities = entityDataStrings.size();
-	std::for_each(std::execution::par, entityDataStrings.begin(), entityDataStrings.end(), [&, this](std::tuple<int, shared_ptr<BuildingEntity>, std::string>& entityDataForOutput) {
+
+#if defined(__APPLE__) || defined(__OSX__)
+	std::for_each(
+#else
+	std::for_each(std::execution::par, 
+#endif
+      entityDataStrings.begin(), entityDataStrings.end(), [&, this](std::tuple<int, shared_ptr<BuildingEntity>, std::string>& entityDataForOutput) {
 		shared_ptr<BuildingEntity> obj = std::get<1>(entityDataForOutput);
 		if (obj.use_count() < 2)
 		{


### PR DESCRIPTION
Some compilers, such as Apple Clang, do not yet support execution policies.   ( https://en.cppreference.com/w/cpp/17 )

Provide support for such compilers.
