### PR TITLE
Don't recreate stream and locale in loop

### DIFF
--- a/IfcPlusPlus/src/ifcpp/writer/WriterSTEP.cpp
+++ b/IfcPlusPlus/src/ifcpp/writer/WriterSTEP.cpp
@@ -39,7 +39,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OU
 void WriterSTEP::writeModelToStream(std::stringstream& stream, shared_ptr<BuildingModel> model)
 {
 	//imbue C locale to always use dots as decimal separator
-	stream.imbue(std::locale("C"));
+	stream.imbue(std::locale::classic());
 
 	const std::string& file_header_str = model->getFileHeader();
 	if(file_header_str.size() == 0)
@@ -70,6 +70,8 @@ void WriterSTEP::writeModelToStream(std::stringstream& stream, shared_ptr<Buildi
 	auto t_start = std::chrono::high_resolution_clock::now();
 	std::atomic<int> counter = 0;
 	size_t numEntities = entityDataStrings.size();
+	std::stringstream tmpStream;
+	tmpStream.imbue(std::locale::classic());
 	FOR_EACH_LOOP entityDataStrings.begin(), entityDataStrings.end(), [&, this](std::tuple<int, shared_ptr<BuildingEntity>, std::string>& entityDataForOutput) {
 		shared_ptr<BuildingEntity> obj = std::get<1>(entityDataForOutput);
 		if (obj.use_count() < 2)
@@ -80,8 +82,6 @@ void WriterSTEP::writeModelToStream(std::stringstream& stream, shared_ptr<Buildi
 				return;
 			}
 		}
-		std::stringstream tmpStream;
-		tmpStream.imbue(std::locale("C"));
 #ifdef EXTERNAL_WRITE_METHODS
 		getStepLine(obj, tmpStream);
 #else
@@ -89,6 +89,7 @@ void WriterSTEP::writeModelToStream(std::stringstream& stream, shared_ptr<Buildi
 #endif
 		tmpStream << std::endl;
 		std::get<2>(entityDataForOutput) = tmpStream.str();
+		tmpStream.str(std::string());
 
 		counter.fetch_add(1);
 		int currentCount = counter.load();

--- a/IfcPlusPlus/src/ifcpp/writer/WriterSTEP.cpp
+++ b/IfcPlusPlus/src/ifcpp/writer/WriterSTEP.cpp
@@ -70,8 +70,6 @@ void WriterSTEP::writeModelToStream(std::stringstream& stream, shared_ptr<Buildi
 	auto t_start = std::chrono::high_resolution_clock::now();
 	std::atomic<int> counter = 0;
 	size_t numEntities = entityDataStrings.size();
-	std::stringstream tmpStream;
-	tmpStream.imbue(std::locale::classic());
 	FOR_EACH_LOOP entityDataStrings.begin(), entityDataStrings.end(), [&, this](std::tuple<int, shared_ptr<BuildingEntity>, std::string>& entityDataForOutput) {
 		shared_ptr<BuildingEntity> obj = std::get<1>(entityDataForOutput);
 		if (obj.use_count() < 2)
@@ -82,6 +80,8 @@ void WriterSTEP::writeModelToStream(std::stringstream& stream, shared_ptr<Buildi
 				return;
 			}
 		}
+		std::stringstream tmpStream;
+		tmpStream.imbue(std::locale::classic());
 #ifdef EXTERNAL_WRITE_METHODS
 		getStepLine(obj, tmpStream);
 #else
@@ -89,7 +89,6 @@ void WriterSTEP::writeModelToStream(std::stringstream& stream, shared_ptr<Buildi
 #endif
 		tmpStream << std::endl;
 		std::get<2>(entityDataForOutput) = tmpStream.str();
-		tmpStream.str(std::string());
 
 		counter.fetch_add(1);
 		int currentCount = counter.load();


### PR DESCRIPTION
Using `std::locale::classic()` instead of creating a new `std::locale` object on each iteration of the loop gives a massive performance boost. ~~Moving `std::stringstream` out of the loop further improves performance.~~

These are results from my benchmark:
```
Run on (20 X 2112 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x10)
  L1 Instruction 32 KiB (x10)
  L2 Unified 1280 KiB (x10)
  L3 Unified 25600 KiB (x1)
----------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations
----------------------------------------------------------------------
NewLocaleEveryIteration          15269 ns        15346 ns        44800
LocaleClassicEveryIteration        560 ns          558 ns      1120000
StreamClearStr                     379 ns          377 ns      1866667
Format                            37.0 ns         36.8 ns     18666667
fmt_lib                           58.4 ns         58.6 ns     11200000
to_chars                          12.8 ns         12.8 ns     56000000
```